### PR TITLE
Continue Sever requests test assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ python:
 - '3.6'
 - '3.7'
 - '3.8'
-- 3.8-dev
+- '3.8-dev'
 before_install:
 - pip install -U pip
 - pip install -U setuptools
 - pip install -U wheel
 install:
-- pip install tox-travis .[devel]
+- pip install tox-travis
 script:
 - tox

--- a/assertions/constants.py
+++ b/assertions/constants.py
@@ -265,6 +265,31 @@ class Assertion(NoValue):
         'A PATCH request with fewer elements than in the current array shall '
         'remove the remaining elements of the array.'
     )
+    REQ_PUT_NOT_IMPLEMENTED = (
+        'If a service does not implement this method, the service shall '
+        'return the HTTP 405 Method Not Allowed status code.'
+    )
+    REQ_POST_CREATE_VIA_COLLECTION = (
+        'To create a resource, services shall support the POST method on '
+        'resource collections.'
+    )
+    REQ_POST_CREATE_URI_IN_LOCATION_HDR = (
+        'Additionally, the service shall set the Location header in the '
+        'response to the URI of the new resource.'
+    )
+    REQ_POST_CREATE_TO_MEMBERS_PROP = (
+        'Submitting a POST request to a resource collection is equivalent to '
+        'submitting the same request to the Members property of that resource '
+        'collection. Services that support the addition of Members to a '
+        'resource collection shall support both forms.'
+    )
+    REQ_POST_CREATE_NOT_SUPPORTED = (
+        'If the service does not enable creation of resources, the service '
+        'shall return the HTTP 405 Method Not Allowed status code.'
+    )
+    REQ_POST_CREATE_NOT_IDEMPOTENT = (
+        'The POST operation shall not be idempotent.'
+    )
     # Service responses assertions (prefix of "RESP_")
     RESP_HEADERS = (
         'Redfish Services shall return the HTTP 1.1 Specification-defined '

--- a/assertions/constants.py
+++ b/assertions/constants.py
@@ -290,6 +290,13 @@ class Assertion(NoValue):
     REQ_POST_CREATE_NOT_IDEMPOTENT = (
         'The POST operation shall not be idempotent.'
     )
+    REQ_DELETE_METHOD_REQUIRED = (
+        'To remove a resource, the service shall support the DELETE method.'
+    )
+    REQ_DELETE_NON_DELETABLE_RESOURCE = (
+        'If the resource can never be deleted, the service shall return the '
+        'HTTP 405 Method Not Allowed status code.'
+    )
     # Service responses assertions (prefix of "RESP_")
     RESP_HEADERS = (
         'Redfish Services shall return the HTTP 1.1 Specification-defined '

--- a/assertions/resources.py
+++ b/assertions/resources.py
@@ -88,7 +88,7 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
 
     r = sut.session.get(sut.rhost + uri)
     yield {'uri': uri, 'response': r}
-    root = r.json()
+    root = r.json() if r.status_code == requests.codes.OK else {}
 
     sut.set_version(root.get('RedfishVersion', '1.0.0'))
     sut.set_product(root.get('Product', 'N/A'))

--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -531,18 +531,30 @@ def test_session_post_response(sut: SystemUnderTest):
                 sut.log(Result.FAIL, 'POST', response.status_code,
                         sut.sessions_uri, Assertion.SEC_SESSION_POST_RESPONSE,
                         msg)
-        data = response.json()
-        missing_props = []
-        for prop in ['@odata.id', '@odata.type', 'Id', 'Name', 'UserName']:
-            if prop not in data:
-                missing_props.append(prop)
-        if missing_props:
+        if response.status_code == requests.codes.CREATED:
+            data = response.json()
+            missing_props = []
+            for prop in ['@odata.id', '@odata.type', 'Id', 'Name', 'UserName']:
+                if prop not in data:
+                    missing_props.append(prop)
+            if missing_props:
+                failed = True
+                msg = ('Response payload for POST to %s did not contain full '
+                       'representation of the new session resource; missing '
+                       'properties: %s ' % (sut.sessions_uri, missing_props))
+                sut.log(Result.FAIL, 'POST', response.status_code,
+                        sut.sessions_uri, Assertion.SEC_SESSION_POST_RESPONSE,
+                        msg)
+        else:
             failed = True
-            msg = ('Response payload for POST to %s did not contain full '
-                   'representation of the new session resource; missing '
-                   'properties: %s ' % (sut.sessions_uri, missing_props))
+            msg = ('Response for POST to %s returned status %s, expected '
+                   'status %s in order to return full representation of the '
+                   'new session resource' %
+                   (sut.sessions_uri, response.status_code,
+                    requests.codes.CREATED))
             sut.log(Result.FAIL, 'POST', response.status_code,
-                    sut.sessions_uri, Assertion.SEC_SESSION_POST_RESPONSE, msg)
+                    sut.sessions_uri, Assertion.SEC_SESSION_POST_RESPONSE,
+                    msg)
         if not failed:
             sut.log(Result.PASS, 'POST', response.status_code,
                     sut.sessions_uri, Assertion.SEC_SESSION_POST_RESPONSE,

--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -636,7 +636,7 @@ def test_session_termination_side_effects(sut: SystemUnderTest):
                 # read from the SSE stream
                 try:
                     lines = response.iter_lines()
-                    for line in lines:
+                    for _ in lines:
                         sut.log(Result.PASS, 'GET', response.status_code,
                                 sut.server_sent_event_uri,
                                 Assertion.SEC_SESSION_TERMINATION_SIDE_EFFECTS,

--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -954,13 +954,9 @@ def test_priv_predefined_roles_not_modifiable(sut: SystemUnderTest):
                 r = sut.session.get(sut.rhost + uri)
                 if r.ok:
                     d = r.json()
-                    privs = d.get('AssignedPrivileges')
-                    if test_priv in privs:
-                        new_privs = [{}] * len(privs)
-                        for i in range(len(privs)):
-                            if privs[i] == test_priv:
-                                new_privs[i] = None
-                        payload = {'AssignedPrivileges': new_privs}
+                    patched_privs = d.get('AssignedPrivileges')
+                    if test_priv in patched_privs:
+                        payload = {'AssignedPrivileges': privs}
                         etag = r.headers.get('ETag')
                         headers = {'If-Match': etag} if etag else {}
                         sut.session.patch(

--- a/assertions/service_requests.py
+++ b/assertions/service_requests.py
@@ -1327,15 +1327,18 @@ def test_delete(sut: SystemUnderTest):
 
 def test_post_action(sut: SystemUnderTest):
     """Perform tests from the 'POST (Action)' sub-section of the spec."""
+    # NOTE(bdodd): Actions better tested in the Redfish-Usecase-Checkers
 
 
 def test_operation_apply_time(sut: SystemUnderTest):
     """Perform tests from the 'Operation apply time' sub-section of the
     spec."""
+    # TODO(bdodd): Need an operation to test that will be minimally disruptive
 
 
 def test_deep_operations(sut: SystemUnderTest):
     """Perform tests from the 'Deep operations' sub-section of the spec."""
+    # TODO(bdodd): These will be challenging to test; defer for now
 
 
 def test_service_requests(sut: SystemUnderTest):

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -36,7 +36,7 @@ class Resources(TestCase):
         add_response(self.sut, self.sut.sessions_uri, 'POST',
                      requests.codes.CREATED,
                      request_type=RequestType.NO_AUTH)
-        add_response(self.sut, '/redfish/v1/AccountsService/Accounts/3/',
+        add_response(self.sut, '/redfish/v1/AccountsService/Accounts/3',
                      'PATCH', requests.codes.NOT_ALLOWED,
                      request_type=RequestType.NO_AUTH)
 

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -1175,7 +1175,7 @@ class SecurityDetails(TestCase):
                       '%s' % (test_priv, 'ReadOnly'),
                       result['msg'])
 
-    def test_test_priv_predefined_roles_not_modifiable_not_pass(self):
+    def test_test_priv_predefined_roles_not_modifiable_pass(self):
         ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
         test_priv = 'RfProtoValTestPriv'
         etag = 'abcd1234'
@@ -1205,7 +1205,7 @@ class SecurityDetails(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
-    def test_test_priv_predefined_roles_not_modifiable_not_fail1(self):
+    def test_test_priv_predefined_roles_not_modifiable_fail1(self):
         ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
         test_priv = 'RfProtoValTestPriv'
         etag = 'abcd1234'
@@ -1238,7 +1238,7 @@ class SecurityDetails(TestCase):
                       (ro_uri, 'ReadOnly', requests.codes.OK),
                       result['msg'])
 
-    def test_test_priv_predefined_roles_not_modifiable_not_fail2(self):
+    def test_test_priv_predefined_roles_not_modifiable_fail2(self):
         ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
         test_priv = 'RfProtoValTestPriv'
         etag = 'abcd1234'
@@ -1274,7 +1274,7 @@ class SecurityDetails(TestCase):
         sec.test_priv_predefined_roles_not_modifiable(self.sut)
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + ro_uri,
-            json={'AssignedPrivileges': [{}, {}, None]},
+            json={'AssignedPrivileges': ['Login', 'ConfigureSelf', None]},
             headers={'If-Match': etag})
         result = get_result(
             self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -21,7 +21,7 @@ class SecurityDetails(TestCase):
         super(SecurityDetails, self).setUp()
         self.sut = SystemUnderTest('https://127.0.0.1:8000', 'oper', 'xyzzy')
         self.sut.set_sessions_uri('/redfish/v1/SessionService/Sessions')
-        self.account_uri = '/redfish/v1/AccountsService/Accounts/3/'
+        self.account_uri = '/redfish/v1/AccountsService/Accounts/3'
         self.mock_session = mock.MagicMock(spec=requests.Session)
         self.sut._set_session(self.mock_session)
         patch_post = mock.patch('assertions.security_details.requests.post')
@@ -498,7 +498,7 @@ class SecurityDetails(TestCase):
         response = self.sut.get_response(
             'POST', self.sut.sessions_uri,
             request_type=RequestType.HTTP_BASIC_AUTH)
-        response.url = 'http://127.0.0.1:8000/redfish/v1/Sessions/'
+        response.url = 'http://127.0.0.1:8000/redfish/v1/Sessions'
         sec.test_basic_auth_over_https(self.sut)
         result = get_result(self.sut, Assertion.SEC_BASIC_AUTH_OVER_HTTPS,
                             'POST', self.sut.sessions_uri)
@@ -1029,7 +1029,7 @@ class SecurityDetails(TestCase):
                       % self.account_uri, result['msg'])
 
     def test_test_priv_support_predefined_roles_pass(self):
-        uri = '/redfish/v1/AccountsService/Roles/Operator/'
+        uri = '/redfish/v1/AccountsService/Roles/Operator'
         payload = {
             'Id': 'Operator',
             'AssignedPrivileges': [
@@ -1048,7 +1048,7 @@ class SecurityDetails(TestCase):
         self.assertEqual(Result.PASS, result['result'])
 
     def test_test_priv_support_predefined_roles_fail1(self):
-        oper_uri = '/redfish/v1/AccountsService/Roles/Operator/'
+        oper_uri = '/redfish/v1/AccountsService/Roles/Operator'
         payload = {
             'Id': 'Operator',
             'AssignedPrivileges': [
@@ -1059,7 +1059,7 @@ class SecurityDetails(TestCase):
         }
         add_response(self.sut, oper_uri, 'GET', requests.codes.OK,
                      res_type=ResourceType.ROLE, json=payload)
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
+        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
         payload = {
             'Id': 'ReadOnly',
             'AssignedPrivileges': [
@@ -1086,7 +1086,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_support_predefined_roles_fail2(self):
-        oper_uri = '/redfish/v1/AccountsService/Roles/Operator/'
+        oper_uri = '/redfish/v1/AccountsService/Roles/Operator'
         payload = {
             'Id': 'Operator',
             'AssignedPrivileges': [
@@ -1098,7 +1098,7 @@ class SecurityDetails(TestCase):
         }
         add_response(self.sut, oper_uri, 'GET', requests.codes.OK,
                      res_type=ResourceType.ROLE, json=payload)
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
+        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
         payload = {
             'Id': 'ReadOnly',
             'AssignedPrivileges': [
@@ -1136,7 +1136,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_predefined_roles_not_modifiable_not_tested2(self):
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
+        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
         payload = {
             'Id': 'ReadOnly',
             'AssignedPrivileges': []
@@ -1153,7 +1153,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_predefined_roles_not_modifiable_not_tested3(self):
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
+        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
         test_priv = 'RfProtoValTestPriv'
         payload = {
             'Id': 'ReadOnly',
@@ -1176,7 +1176,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_predefined_roles_not_modifiable_pass(self):
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
+        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
         test_priv = 'RfProtoValTestPriv'
         etag = 'abcd1234'
         payload = {
@@ -1206,7 +1206,7 @@ class SecurityDetails(TestCase):
         self.assertEqual(Result.PASS, result['result'])
 
     def test_test_priv_predefined_roles_not_modifiable_fail1(self):
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
+        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
         test_priv = 'RfProtoValTestPriv'
         etag = 'abcd1234'
         payload = {
@@ -1239,7 +1239,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_predefined_roles_not_modifiable_fail2(self):
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly/'
+        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
         test_priv = 'RfProtoValTestPriv'
         etag = 'abcd1234'
         payload = {
@@ -1287,7 +1287,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_one_role_per_user_pass(self):
-        uri = '/redfish/v1/AccountsService/Accounts/carol/'
+        uri = '/redfish/v1/AccountsService/Accounts/carol'
         payload = {
             'UserName': 'carol',
             'RoleId': 'ReadOnly'
@@ -1302,7 +1302,7 @@ class SecurityDetails(TestCase):
         self.assertEqual(Result.PASS, result['result'])
 
     def test_test_priv_one_role_per_user_fail(self):
-        uri = '/redfish/v1/AccountsService/Accounts/bob/'
+        uri = '/redfish/v1/AccountsService/Accounts/bob'
         payload = {
             'UserName': 'bob'
         }
@@ -1319,7 +1319,7 @@ class SecurityDetails(TestCase):
 
     def test_test_priv_roles_assigned_at_account_create_pass(self):
         user = 'rfpv4f0a'
-        uri = '/redfish/v1/AccountsService/Accounts/%s/' % user
+        uri = '/redfish/v1/AccountsService/Accounts/%s' % user
         payload = {
             'UserName': user,
             'RoleId': 'ReadOnly'
@@ -1335,7 +1335,7 @@ class SecurityDetails(TestCase):
 
     def test_test_priv_roles_assigned_at_account_create_fail(self):
         user = 'rfpv4f0a'
-        uri = '/redfish/v1/AccountsService/Accounts/%s/' % user
+        uri = '/redfish/v1/AccountsService/Accounts/%s' % user
         payload = {
             'UserName': user
         }
@@ -1361,7 +1361,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_operation_to_priv_mapping_pass(self):
-        uri = '/redfish/v1/AccountsService/Accounts/10/'
+        uri = '/redfish/v1/AccountsService/Accounts/10'
         headers = {'Authorization': 'Basic cmZwdmM1YmY6cDUzMDU5ZWE='}
         response = add_response(
             self.sut, uri, 'PATCH', requests.codes.UNAUTHORIZED,
@@ -1376,7 +1376,7 @@ class SecurityDetails(TestCase):
         self.assertEqual(Result.PASS, result['result'])
 
     def test_test_priv_operation_to_priv_mapping_warn(self):
-        uri = '/redfish/v1/AccountsService/Accounts/10/'
+        uri = '/redfish/v1/AccountsService/Accounts/10'
         headers = {'Authorization': 'Basic cmZwdmM1YmY6cDUzMDU5ZWE='}
         response = add_response(
             self.sut, uri, 'PATCH', requests.codes.FORBIDDEN,
@@ -1395,7 +1395,7 @@ class SecurityDetails(TestCase):
                       result['msg'])
 
     def test_test_priv_operation_to_priv_mapping_fail(self):
-        uri = '/redfish/v1/AccountsService/Accounts/10/'
+        uri = '/redfish/v1/AccountsService/Accounts/10'
         headers = {'Authorization': 'Basic cmZwdmM1YmY6cDUzMDU5ZWE='}
         user = 'rfpvc5bf'
         response = add_response(

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -568,13 +568,27 @@ class SecurityDetails(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
-    def test_test_session_post_response_fail(self):
+    def test_test_session_post_response_fail1(self):
         sec.test_session_post_response(self.sut)
         result = get_result(self.sut, Assertion.SEC_SESSION_POST_RESPONSE,
                             'POST', self.sut.sessions_uri)
         self.assertIsNotNone(result)
         self.assertEqual(Result.FAIL, result['result'])
         self.assertIn('did not contain full representation of the new session',
+                      result['msg'])
+
+    def test_test_session_post_response_fail2(self):
+        headers = {'X-Auth-Token': 'abcdef40',
+                   'Location': '/redfish/v1/SessionService/Sessions/1'}
+        add_response(self.sut, self.sut.sessions_uri, 'POST',
+                     requests.codes.NO_CONTENT, headers=headers)
+        sec.test_session_post_response(self.sut)
+        result = get_result(self.sut, Assertion.SEC_SESSION_POST_RESPONSE,
+                            'POST', self.sut.sessions_uri)
+        self.assertIsNotNone(result)
+        self.assertIn('status %s, expected status %s in order to return full '
+                      'representation' % (requests.codes.NO_CONTENT,
+                                          requests.codes.CREATED),
                       result['msg'])
 
     def test_test_session_post_response_not_tested(self):

--- a/unittests/test_service_requests.py
+++ b/unittests/test_service_requests.py
@@ -24,7 +24,7 @@ class ServiceRequests(TestCase):
         self.sut._set_session(self.mock_session)
         self.sse_uri = '/redfish/v1/EventService/SSE'
         self.accounts_uri = '/redfish/v1/AccountsService/Accounts'
-        self.account_uri = self.accounts_uri + '/3/'
+        self.account_uri = self.accounts_uri + '/3'
         self.sut.set_supported_query_params({'ExcerptQuery': True})
         self.mgr_net_proto_uri = '/redfish/v1/Managers/BMC/NetworkProtocol'
         self.sut.set_mgr_net_proto_uri(self.mgr_net_proto_uri)

--- a/unittests/test_sut.py
+++ b/unittests/test_sut.py
@@ -22,18 +22,18 @@ class Sut(TestCase):
         self.password = 'xyzzy'
         self.version = '1.6.0'
         self.version_tuple = (1, 6, 0)
-        self.sessions_uri = '/redfish/v1/sessions/'
+        self.sessions_uri = '/redfish/v1/sessions'
         self.active_session_uri = '/redfish/v1/sessions/12345'
         self.active_session_key = 'token98765'
         self.session = mock.Mock()
-        self.systems_uri = '/redfish/v1/Systems/'
-        self.managers_uri = '/redfish/v1/Managers/'
-        self.chassis_uri = '/redfish/v1/Chassis/'
-        self.account_service_uri = '/redfish/v1/AccountService/'
-        self.accounts_uri = '/redfish/v1/accounts/'
-        self.roles_uri = '/redfish/v1/roles/'
-        self.cert_service_uri = '/redfish/v1/CertificateService/'
-        self.event_service_uri = '/redfish/v1/EventService/'
+        self.systems_uri = '/redfish/v1/Systems'
+        self.managers_uri = '/redfish/v1/Managers'
+        self.chassis_uri = '/redfish/v1/Chassis'
+        self.account_service_uri = '/redfish/v1/AccountService'
+        self.accounts_uri = '/redfish/v1/accounts'
+        self.roles_uri = '/redfish/v1/roles'
+        self.cert_service_uri = '/redfish/v1/CertificateService'
+        self.event_service_uri = '/redfish/v1/EventService'
         self.privilege_registry_uri = '/redfish/v1/AccountService/PrivilegeMap'
         self.sut = SystemUnderTest(self.rhost, self.username, self.password)
         self.sut.set_avoid_http_redirect(False)
@@ -152,7 +152,7 @@ class Sut(TestCase):
 
     @mock.patch('assertions.system_under_test.logging.error')
     def test_bad_nav_prop(self, mock_error):
-        self.sut.set_nav_prop_uri('Foo', '/redfish/v1/Foo/')
+        self.sut.set_nav_prop_uri('Foo', '/redfish/v1/Foo')
         self.assertEqual(mock_error.call_count, 1)
         args = mock_error.call_args[0]
         self.assertIn('set_nav_prop_uri() called with', args[0])

--- a/unittests/test_utils.py
+++ b/unittests/test_utils.py
@@ -23,7 +23,7 @@ class Utils(TestCase):
     def setUp(self):
         super(Utils, self).setUp()
         self.sut = SystemUnderTest('http://127.0.0.1:8000', 'oper', 'xyzzy')
-        self.uri = '/redfish/v1/AccountsService/Accounts/3/'
+        self.uri = '/redfish/v1/AccountsService/Accounts/3'
         self.etag = 'A89B031B62'
         response = mock.Mock(spec=requests.Response)
         response.status_code = requests.codes.OK


### PR DESCRIPTION
Updates in this PR:
- finished the assertions from the Service requests section of the spec
- removes the trailing slash from URIs in unittests

Fixes #4 