### PR TITLE
Complete server response assertions

### DIFF
--- a/assertions/constants.py
+++ b/assertions/constants.py
@@ -352,6 +352,14 @@ class Assertion(NoValue):
         'The token value [from the X-Auth-Token header] shall be '
         'indistinguishable from random.'
     )
+    RESP_STATUS_BAD_REQUEST = (
+        '[In a 400 Bad Request response] the response body shall return an '
+        'extended error as defined in the Error responses clause.'
+    )
+    RESP_STATUS_INTERNAL_SERVER_ERROR = (
+        '[In a 500 Internal Server Error response] the response body shall '
+        'return an extended error as defined in the Error responses clause.'
+    )
     # Service details assertions (prefix of "SERV_")
     SERV_EVENT_POST_RESP = (
         'If the [Event Service] subscription request succeeds, the service '

--- a/assertions/constants.py
+++ b/assertions/constants.py
@@ -360,6 +360,29 @@ class Assertion(NoValue):
         '[In a 500 Internal Server Error response] the response body shall '
         'return an extended error as defined in the Error responses clause.'
     )
+    RESP_ODATA_METADATA_MIME_TYPE = (
+        'The service shall use the application/xml or '
+        'application/xml;charset=utf-8 MIME types to return the OData '
+        'metadata document as an XML document.'
+    )
+    RESP_ODATA_METADATA_ENTITY_CONTAINER = (
+        'The service\'s OData metadata document shall include an '
+        'EntityContainer that defines the top-level resources and resource '
+        'collections.'
+    )
+    RESP_ODATA_SERVICE_MIME_TYPE = (
+        'The service shall use the application/json MIME type to return the '
+        'OData service document as a JSON object.'
+    )
+    RESP_ODATA_SERVICE_CONTEXT = (
+        'The JSON object shall contain the @odata.context context property '
+        'set to /redfish/v1/$metadata .'
+    )
+    RESP_ODATA_SERVICE_VALUE_PROP = (
+        'The JSON object shall include a value property set to a JSON array '
+        'that contains an entry for the Service Root and each resource that '
+        'is a direct child of the Service Root.'
+    )
     # Service details assertions (prefix of "SERV_")
     SERV_EVENT_POST_RESP = (
         'If the [Event Service] subscription request succeeds, the service '

--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -705,9 +705,10 @@ def test_accounts_support_etags(sut: SystemUnderTest):
             else:
                 msg = ('%s request to account URI %s with stale If-Match '
                        'header failed with status %s; expected it to fail '
-                       'with status %s' % (response.request.method, uri,
-                                           response.status_code,
-                                           requests.codes.PRECONDITION_FAILED))
+                       'with status %s; extended error: %s' %
+                       (response.request.method, uri, response.status_code,
+                        requests.codes.PRECONDITION_FAILED,
+                        utils.get_extended_error(response)))
                 sut.log(Result.WARN, response.request.method,
                         response.status_code, uri,
                         Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS, msg)
@@ -1050,9 +1051,10 @@ def test_priv_operation_to_priv_mapping(sut: SystemUnderTest):
             else:
                 msg = ('PATCH request to account %s using credentials of '
                        'other user %s failed with status %s, but expected it '
-                       'to fail with status %s' % (
+                       'to fail with status %s; extended error: %s' % (
                         uri, user, response.status_code,
-                        requests.codes.UNAUTHORIZED))
+                        requests.codes.UNAUTHORIZED,
+                        utils.get_extended_error(response)))
                 sut.log(Result.WARN, 'PATCH', response.status_code, uri,
                         Assertion.SEC_PRIV_OPERATION_TO_PRIV_MAPPING,
                         msg)

--- a/assertions/service_details.py
+++ b/assertions/service_details.py
@@ -47,9 +47,10 @@ def test_event_service_subscription(sut: SystemUnderTest):
                         Assertion.SERV_EVENT_POST_RESP, msg)
         else:
             msg = ('Response from event subscription POST request to %s '
-                   'returned status code %s; expected %s' % (
-                    sut.subscriptions_uri, response.status_code,
-                    requests.codes.CREATED))
+                   'returned status code %s; expected %s; extended error: %s'
+                   % (sut.subscriptions_uri, response.status_code,
+                      requests.codes.CREATED,
+                      utils.get_extended_error(response)))
             sut.log(Result.FAIL, response.request.method,
                     response.status_code, sut.subscriptions_uri,
                     Assertion.SERV_EVENT_POST_RESP, msg)

--- a/assertions/service_requests.py
+++ b/assertions/service_requests.py
@@ -33,7 +33,9 @@ def test_header(sut: SystemUnderTest, header, header_values, uri, assertion,
             break
         else:
             msg = ('GET request to %s failed with status code %s using header '
-                   '%s: %s' % (uri, response.status_code, header, val))
+                   '%s: %s; extended error: %s' %
+                   (uri, response.status_code, header, val,
+                    utils.get_extended_error(response)))
             sut.log(Result.FAIL, 'GET', response.status_code, uri,
                     assertion, msg)
 
@@ -286,7 +288,8 @@ def test_get_no_accept_header(sut: SystemUnderTest):
             sut.log(Result.FAIL, 'GET', response.status_code, uri,
                     Assertion.REQ_GET_NO_ACCEPT_HEADER, msg)
     else:
-        msg = ('GET request to URI %s with no Accept header failed' % uri)
+        msg = ('GET request to URI %s with no Accept header failed; extended '
+               'error: %s' % (uri, utils.get_extended_error(response)))
         sut.log(Result.FAIL, 'GET', response.status_code, uri,
                 Assertion.REQ_GET_NO_ACCEPT_HEADER, msg)
 
@@ -549,8 +552,10 @@ def test_query_unsupported_dollar_params(sut: SystemUnderTest):
         test_query_unsupported_dollar_params_ext_error(sut, uri, response)
     else:
         msg = ('GET request with unknown query parameter that starts with $ '
-               '(URI %s) returned status %s; expected status %s' %
-               (uri, response.status_code, requests.codes.NOT_IMPLEMENTED))
+               '(URI %s) returned status %s; expected status %s; extended '
+               'error: %s' % (uri, response.status_code,
+                              requests.codes.NOT_IMPLEMENTED,
+                              utils.get_extended_error(response)))
         sut.log(Result.FAIL, 'GET', response.status_code, uri,
                 Assertion.REQ_QUERY_UNSUPPORTED_DOLLAR_PARAMS, msg)
         if not response.ok:
@@ -662,8 +667,10 @@ def test_patch_mixed_props(sut: SystemUnderTest):
                 sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                         Assertion.REQ_PATCH_MIXED_PROPS, msg)
         else:
-            msg = ('The service response returned status code %s; expected %s'
-                   % (response.status_code, requests.codes.OK))
+            msg = ('The service response returned status code %s; expected '
+                   '%s; extended error: %s'
+                   % (response.status_code, requests.codes.OK,
+                      utils.get_extended_error(response)))
             sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                     Assertion.REQ_PATCH_MIXED_PROPS, msg)
 
@@ -688,12 +695,15 @@ def test_patch_bad_prop(sut: SystemUnderTest):
                         Assertion.REQ_PATCH_BAD_PROP, 'Test passed')
             else:
                 msg = ('The service response did not include a message '
-                       'that lists the non-updatable property')
+                       'that lists the non-updatable property; extended '
+                       'error: %s' % utils.get_extended_error(response))
                 sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                         Assertion.REQ_PATCH_BAD_PROP, msg)
         else:
-            msg = ('The service response returned status code %s; expected %s'
-                   % (response.status_code, requests.codes.BAD_REQUEST))
+            msg = ('The service response returned status code %s; expected '
+                   '%s; extended error: %s'
+                   % (response.status_code, requests.codes.BAD_REQUEST,
+                      utils.get_extended_error(response)))
             sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                     Assertion.REQ_PATCH_BAD_PROP, msg)
 
@@ -762,7 +772,8 @@ def test_patch_odata_props(sut: SystemUnderTest):
                         Assertion.REQ_PATCH_ODATA_PROPS, 'Test passed')
             else:
                 msg = ('The service response did not include the NoOperation '
-                       'message from the Base Message Registry')
+                       'message from the Base Message Registry; extended '
+                       'error: %s' % utils.get_extended_error(response))
                 sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                         Assertion.REQ_PATCH_ODATA_PROPS, msg)
         elif response.status_code in [requests.codes.OK,
@@ -774,8 +785,9 @@ def test_patch_odata_props(sut: SystemUnderTest):
             exp_codes = [requests.codes.OK, requests.codes.ACCEPTED,
                          requests.codes.NO_CONTENT, requests.codes.BAD_REQUEST]
             msg = ('The service response returned status code %s; expected '
-                   'one of %s'
-                   % (response.status_code, exp_codes))
+                   'one of %s; extended error: %s'
+                   % (response.status_code, exp_codes,
+                      utils.get_extended_error(response)))
             sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                     Assertion.REQ_PATCH_ODATA_PROPS, msg)
 
@@ -852,14 +864,15 @@ def test_patch_array_element_remove(sut: SystemUnderTest):
                         Assertion.REQ_PATCH_ARRAY_ELEMENT_REMOVE, msg)
         else:
             msg = ('PATCH failed with status %s; resource: %s; '
-                   'PATCH payload: %s' % (
+                   'PATCH payload: %s; extended error: %s' % (
                        response.status_code, payload1,
-                       payload2))
+                       payload2, utils.get_extended_error(response)))
             sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                     Assertion.REQ_PATCH_ARRAY_ELEMENT_REMOVE, msg)
     else:
-        msg = ('PATCH failed with status %s; PATCH payload: %s' %
-               (response.status_code, payload1))
+        msg = ('PATCH failed with status %s; PATCH payload: %s; extended '
+               'error: %s' % (response.status_code, payload1,
+                              utils.get_extended_error(response)))
         sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                 Assertion.REQ_PATCH_ARRAY_ELEMENT_REMOVE, msg)
 
@@ -996,14 +1009,15 @@ def test_patch_array_truncate(sut: SystemUnderTest):
                         Assertion.REQ_PATCH_ARRAY_TRUNCATE, msg)
         else:
             msg = ('PATCH failed with status %s; resource: %s; '
-                   'PATCH payload: %s' %
+                   'PATCH payload: %s; extended error: %s' %
                    (response.status_code, payload1,
-                    payload2))
+                    payload2, utils.get_extended_error(response)))
             sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                     Assertion.REQ_PATCH_ARRAY_TRUNCATE, msg)
     else:
-        msg = ('PATCH failed with status %s; PATCH payload: %s' %
-               (response.status_code, payload1))
+        msg = ('PATCH failed with status %s; PATCH payload: %s; extended '
+               'error: %s' % (response.status_code, payload1,
+                              utils.get_extended_error(response)))
         sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                 Assertion.REQ_PATCH_ARRAY_TRUNCATE, msg)
 

--- a/assertions/service_requests.py
+++ b/assertions/service_requests.py
@@ -508,7 +508,8 @@ def test_query_ignore_unsupported(sut: SystemUnderTest):
     else:
         msg = ('GET request with unknown query parameter (URI %s) failed with '
                'status %s; expected query param to be ignored and the request '
-               'to succeed' % (uri, response.status_code))
+               'to succeed; extended error: %s' %
+               (uri, response.status_code, utils.get_extended_error(response)))
         sut.log(Result.FAIL, 'GET', response.status_code, uri,
                 Assertion.REQ_QUERY_IGNORE_UNSUPPORTED, msg)
 
@@ -526,7 +527,8 @@ def test_query_unsupported_dollar_params_ext_error(
         else:
             msg = ('The response contained an extended error, but the '
                    'unsupported query parameter $rpvunknown was not '
-                   'indicated in the error message text')
+                   'indicated in the error message text; extended error: %s'
+                   % utils.get_extended_error(response))
             sut.log(Result.FAIL, 'GET', response.status_code, uri,
                     Assertion.REQ_QUERY_UNSUPPORTED_PARAMS_EXT_ERROR,
                     msg)
@@ -1096,8 +1098,9 @@ def test_post_create_to_members_prop(sut: SystemUnderTest):
             if session_uri:
                 sut.session.delete(sut.rhost + session_uri)
     else:
-        msg = ('POST to Members property URI %s failed with status %s' %
-               (uri, response.status_code))
+        msg = ('POST to Members property URI %s failed with status %s; '
+               'extended error: %s' %
+               (uri, response.status_code, utils.get_extended_error(response)))
         sut.log(Result.FAIL, 'POST', response.status_code, uri,
                 Assertion.REQ_POST_CREATE_TO_MEMBERS_PROP,
                 msg)
@@ -1120,9 +1123,10 @@ def test_post_create_not_supported(sut: SystemUnderTest):
                 Assertion.REQ_POST_CREATE_NOT_SUPPORTED,
                 'Test passed')
     else:
-        msg = ('POST request to URI %s failed with %s; expected %s' %
-               (sut.accounts_uri, response.status_code,
-                requests.codes.METHOD_NOT_ALLOWED))
+        msg = ('POST request to URI %s failed with %s; expected %s; extended '
+               'error: %s' % (sut.accounts_uri, response.status_code,
+                              requests.codes.METHOD_NOT_ALLOWED,
+                              utils.get_extended_error(response)))
         sut.log(Result.FAIL, 'POST', response.status_code, sut.accounts_uri,
                 Assertion.REQ_POST_CREATE_NOT_SUPPORTED,
                 msg)
@@ -1202,7 +1206,8 @@ def test_delete_method_required(sut: SystemUnderTest):
 
     if not passed:
         if fail_uri:
-            msg = 'No successful DELETE responses found'
+            msg = ('No successful DELETE responses found; extended error: %s'
+                   % utils.get_extended_error(fail_response))
             sut.log(Result.FAIL, 'DELETE', fail_response.status_code, fail_uri,
                     Assertion.REQ_DELETE_METHOD_REQUIRED, msg)
         else:
@@ -1226,8 +1231,10 @@ def test_delete_non_deletable_resource(sut: SystemUnderTest):
 
     if not passed:
         if warn_uri:
-            msg = ('DELETE request for resource %s failed with status %s' %
-                   (warn_uri, warn_response.status_code))
+            msg = ('DELETE request for resource %s failed with status %s; '
+                   'extended error: %s' %
+                   (warn_uri, warn_response.status_code,
+                    utils.get_extended_error(warn_response)))
             sut.log(Result.WARN, 'DELETE', warn_response.status_code, warn_uri,
                     Assertion.REQ_DELETE_NON_DELETABLE_RESOURCE, msg)
         else:

--- a/assertions/service_responses.py
+++ b/assertions/service_responses.py
@@ -590,7 +590,7 @@ def test_response_status_codes(sut: SystemUnderTest):
 
 
 def test_response_odata_metadata(sut: SystemUnderTest):
-    """Perform tests from the 'SOData metadata' sub-section of the spec."""
+    """Perform tests from the 'OData metadata' sub-section of the spec."""
     test_odata_metadata_mime_type(sut)
     test_odata_metadata_entity_container(sut)
     test_odata_service_mime_type(sut)

--- a/assertions/utils.py
+++ b/assertions/utils.py
@@ -45,7 +45,7 @@ def get_etag_header(sut, session, uri):
     return {'If-Match': etag} if etag else {}
 
 
-def get_response_etag(response):
+def get_response_etag(response: requests.Response):
     etag = None
     if response.ok:
         etag = response.headers.get('ETag')
@@ -54,6 +54,27 @@ def get_response_etag(response):
                 data = response.json()
                 etag = data.get('@odata.etag')
     return etag
+
+
+def get_extended_error(response: requests.Response):
+    message = ''
+    try:
+        data = response.json()
+        if 'error' in data:
+            error = data['error']
+            if 'message' in error:
+                message = error['message']
+            elif 'code' in error:
+                message = error['code']
+            ext_info = error.get('@Message.ExtendedInfo', [])
+            if isinstance(ext_info, list) and len(ext_info) > 0:
+                if 'Message' in ext_info[0]:
+                    message = ext_info[0]['Message']
+                elif 'MessageId' in ext_info[0]:
+                    message = ext_info[0]['MessageId']
+    except Exception:
+        pass
+    return message
 
 
 def get_extended_info_message_keys(body: dict):

--- a/assertions/utils.py
+++ b/assertions/utils.py
@@ -31,6 +31,12 @@ def get_response_media_type(response):
     return header.split(';', 1)[0].strip().lower()
 
 
+def get_response_media_type_charset(response):
+    header = response.headers.get('Content-Type', '')
+    if ';' in header:
+        return header.split(';', 1)[1].strip().lower()
+
+
 def get_etag_header(sut, session, uri):
     response = session.get(sut.rhost + uri)
     etag = None
@@ -360,5 +366,7 @@ def random_sequence(token: str):
         logging.debug('P-value of %s test for token %s is %s' %
                       (func.__name__, token, p))
         if p < 0.01:
+            # print('P-value of %s test for token %s is %s' %
+            #       (func.__name__, token, p))
             return False
     return True

--- a/assertions/utils.py
+++ b/assertions/utils.py
@@ -181,6 +181,7 @@ class FakeSocket(io.BytesIO):
 def sanitize(number, minimum, maximum=None):
     """ Sanity check a given number.
 
+    :param number: the number to sanitize
     :param minimum: the minimum acceptable number
     :param maximum: the maximum acceptable number (optional)
 

--- a/unittests/test_service_responses.py
+++ b/unittests/test_service_responses.py
@@ -694,6 +694,296 @@ class ServiceResponses(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
+    def test_test_odata_metadata_mime_type_not_tested(self):
+        uri = '/redfish/v1/$metadata'
+        resp.test_odata_metadata_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.NOT_TESTED, result['result'])
+        self.assertIn('No response found for URI %s' %
+                      uri, result['msg'])
+
+    def test_test_odata_metadata_mime_type_fail1(self):
+        uri = '/redfish/v1/$metadata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     headers={'Content-Type': 'text/xml'})
+        resp.test_odata_metadata_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('The MIME type for the OData metadata document is %s' %
+                      'text/xml', result['msg'])
+
+    def test_test_odata_metadata_mime_type_fail2(self):
+        uri = '/redfish/v1/$metadata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.NOT_FOUND)
+        resp.test_odata_metadata_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('%s request to URI %s failed with status %s' %
+                      ('GET', uri, requests.codes.NOT_FOUND), result['msg'])
+
+    def test_test_odata_metadata_mime_type_pass1(self):
+        uri = '/redfish/v1/$metadata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     headers={'Content-Type': 'application/xml'})
+        resp.test_odata_metadata_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.PASS, result['result'])
+
+    def test_test_odata_metadata_mime_type_pass2(self):
+        uri = '/redfish/v1/$metadata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     headers={'Content-Type': 'application/xml;charset=utf-8'})
+        resp.test_odata_metadata_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.PASS, result['result'])
+
+    def test_test_odata_metadata_mime_type_pass3(self):
+        uri = '/redfish/v1/$metadata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     headers={'Content-Type':
+                              'application/xml ; charset=UTF-8'})
+        resp.test_odata_metadata_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.PASS, result['result'])
+
+    def test_test_odata_metadata_entity_container_not_tested(self):
+        uri = '/redfish/v1/$metadata'
+        resp.test_odata_metadata_entity_container(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_ENTITY_CONTAINER, 'GET',
+            uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.NOT_TESTED, result['result'])
+        self.assertIn('No response found for URI %s' %
+                      uri, result['msg'])
+
+    def test_test_odata_metadata_entity_container_fail1(self):
+        uri = '/redfish/v1/$metadata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.NOT_FOUND)
+        resp.test_odata_metadata_entity_container(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_ENTITY_CONTAINER, 'GET',
+            uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('%s request to URI %s failed with status %s' %
+                      ('GET', uri, requests.codes.NOT_FOUND), result['msg'])
+
+    def test_test_odata_metadata_entity_container_fail2(self):
+        uri = '/redfish/v1/$metadata'
+        doc = '{"@odata.id": "/redfish/v1/$metadata"}'
+        add_response(self.sut, uri, 'GET', status_code=requests.codes.OK,
+                     text=doc)
+        resp.test_odata_metadata_entity_container(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_ENTITY_CONTAINER, 'GET',
+            uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('ParseError received while trying to read '
+                      'EntityContainer element from the OData metadata '
+                      'document', result['msg'])
+
+    def test_test_odata_metadata_entity_container_fail3(self):
+        uri = '/redfish/v1/$metadata'
+        doc = ('<Edmx><DataServices><Schema>'
+               '</Schema></DataServices></Edmx>')
+        add_response(self.sut, uri, 'GET', status_code=requests.codes.OK,
+                     text=doc)
+        resp.test_odata_metadata_entity_container(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_ENTITY_CONTAINER, 'GET',
+            uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('EntityContainer element not found in OData metadata '
+                      'document', result['msg'])
+
+    def test_test_odata_metadata_entity_container_pass(self):
+        uri = '/redfish/v1/$metadata'
+        doc = ('<Edmx><DataServices><Schema><EntityContainer/>'
+               '</Schema></DataServices></Edmx>')
+        add_response(self.sut, uri, 'GET', status_code=requests.codes.OK,
+                     text=doc)
+        resp.test_odata_metadata_entity_container(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_METADATA_ENTITY_CONTAINER, 'GET',
+            uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.PASS, result['result'])
+
+    def test_test_odata_service_mime_type_not_tested(self):
+        uri = '/redfish/v1/odata'
+        resp.test_odata_service_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.NOT_TESTED, result['result'])
+        self.assertIn('No response found for URI %s' %
+                      uri, result['msg'])
+
+    def test_test_odata_service_mime_type_fail1(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.NOT_FOUND)
+        resp.test_odata_service_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('%s request to URI %s failed with status %s' %
+                      ('GET', uri, requests.codes.NOT_FOUND), result['msg'])
+
+    def test_test_odata_service_mime_type_fail2(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     headers={'Content-Type': 'application/xml'})
+        resp.test_odata_service_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('The MIME type for the OData service document is %s; '
+                      'expected %s' % ('application/xml', 'application/json'),
+                      result['msg'])
+
+    def test_test_odata_service_mime_type_pass(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     headers={'Content-Type': 'application/json'})
+        resp.test_odata_service_mime_type(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_MIME_TYPE, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.PASS, result['result'])
+
+    def test_test_odata_service_context_not_tested(self):
+        uri = '/redfish/v1/odata'
+        resp.test_odata_service_context(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_CONTEXT, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.NOT_TESTED, result['result'])
+        self.assertIn('No response found for URI %s' %
+                      uri, result['msg'])
+
+    def test_test_odata_service_context_fail1(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.NOT_FOUND)
+        resp.test_odata_service_context(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_CONTEXT, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('%s request to URI %s failed with status %s' %
+                      ('GET', uri, requests.codes.NOT_FOUND), result['msg'])
+
+    def test_test_odata_service_context_fail2(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     json={'@odata.context': uri})
+        resp.test_odata_service_context(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_CONTEXT, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('The @odata.context property for the OData service '
+                      'document is %s; expected %s' %
+                      (uri, '/redfish/v1/$metadata'), result['msg'])
+
+    def test_test_odata_service_context_pass(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     json={'@odata.context': '/redfish/v1/$metadata'})
+        resp.test_odata_service_context(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_CONTEXT, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.PASS, result['result'])
+
+    def test_test_odata_service_value_prop_not_tested(self):
+        uri = '/redfish/v1/odata'
+        resp.test_odata_service_value_prop(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_VALUE_PROP, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.NOT_TESTED, result['result'])
+        self.assertIn('No response found for URI %s' %
+                      uri, result['msg'])
+
+    def test_test_odata_service_value_prop_fail1(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.NOT_FOUND)
+        resp.test_odata_service_value_prop(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_VALUE_PROP, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('%s request to URI %s failed with status %s' %
+                      ('GET', uri, requests.codes.NOT_FOUND), result['msg'])
+
+    def test_test_odata_service_value_prop_fail2(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     json={})
+        resp.test_odata_service_value_prop(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_VALUE_PROP, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('The value property for the OData service '
+                      'document is missing', result['msg'])
+
+    def test_test_odata_service_value_prop_fail3(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     json={'value': {}})
+        resp.test_odata_service_value_prop(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_VALUE_PROP, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('The value property for the OData service '
+                      'document is type %s; expected list' % 'dict',
+                      result['msg'])
+
+    def test_test_odata_service_value_prop_pass(self):
+        uri = '/redfish/v1/odata'
+        add_response(self.sut, uri, 'GET',
+                     status_code=requests.codes.OK,
+                     json={'value': []})
+        resp.test_odata_service_value_prop(self.sut)
+        result = get_result(
+            self.sut, Assertion.RESP_ODATA_SERVICE_VALUE_PROP, 'GET', uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.PASS, result['result'])
+
     def test_test_service_responses_cover(self):
         resp.test_service_responses(self.sut)
 

--- a/unittests/test_utils.py
+++ b/unittests/test_utils.py
@@ -67,6 +67,62 @@ class Utils(TestCase):
         etag = utils.get_response_etag(response)
         self.assertEqual(etag, odata_etag)
 
+    def test_get_extended_error(self):
+        response = mock.Mock(spec=requests.Response)
+        body = {
+            "error": {
+                "@Message.ExtendedInfo": [
+                    {
+                        "MessageId": "Base.1.4.NoValidSession",
+                        "Message": "No valid session found"
+                    }
+                ]
+            }
+        }
+        response.json.return_value = body
+        msg = utils.get_extended_error(response)
+        self.assertEqual(msg, 'No valid session found')
+
+        body = {
+            "error": {
+                "@Message.ExtendedInfo": [
+                    {
+                        "MessageId": "Base.1.4.NoValidSession"
+                    }
+                ]
+            }
+        }
+        response.json.return_value = body
+        msg = utils.get_extended_error(response)
+        self.assertEqual(msg, 'Base.1.4.NoValidSession')
+
+        body = {
+            "error": {
+                "code": "Base.1.8.GeneralError",
+                "message": "A general error has occurred. See Resolution for "
+                           "information on how to resolve the error.",
+                "@Message.ExtendedInfo": []
+            }
+        }
+        response.json.return_value = body
+        msg = utils.get_extended_error(response)
+        self.assertEqual(msg, 'A general error has occurred. See Resolution '
+                              'for information on how to resolve the error.')
+
+        body = {
+            "error": {
+                "code": "Base.1.8.GeneralError",
+                "@Message.ExtendedInfo": []
+            }
+        }
+        response.json.return_value = body
+        msg = utils.get_extended_error(response)
+        self.assertEqual(msg, 'Base.1.8.GeneralError')
+
+        response.json.side_effect = ValueError
+        msg = utils.get_extended_error(response)
+        self.assertEqual(msg, '')
+
     def test_get_extended_info_message_keys(self):
         body = {
             "error": {


### PR DESCRIPTION
Updates in this PR:
- Completes the assertions for the "Server responses" spec section
- Add the extended error message to the report for a number of failures 