### PR TITLE
Add try/except around HTTP redirect and SSE stream requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ aenum
 colorama
 pyasn1
 pyasn1-modules
-requests
+requests>=2.23.0
 sseclient-py
 urllib3
 ```

--- a/assertions/service_details.py
+++ b/assertions/service_details.py
@@ -552,7 +552,7 @@ def test_sse_successful_response(sut: SystemUnderTest):
     if response is None:
         response, _ = utils.get_sse_stream(sut)
 
-    if response.ok:
+    if response is not None and response.ok:
         failed = False
         if response.status_code != requests.codes.OK:
             msg = ('Response from GET request to URL %s succeeded with status '
@@ -595,8 +595,8 @@ def test_sse_successful_response(sut: SystemUnderTest):
     else:
         msg = ('Response from GET request to URL %s was not successful; '
                'unable to test this assertion' % sut.server_sent_event_uri)
-        sut.log(Result.NOT_TESTED, 'GET', response.status_code,
-                sut.server_sent_event_uri,
+        code = response.status_code if response is not None else ''
+        sut.log(Result.NOT_TESTED, 'GET', code, sut.server_sent_event_uri,
                 Assertion.SERV_SSE_SUCCESSFUL_RESPONSE, msg)
 
 
@@ -822,7 +822,7 @@ def test_sse_open_creates_event_dest(sut: SystemUnderTest):
 
     response, event_dest_uri = utils.get_sse_stream(sut)
 
-    if response.ok:
+    if response is not None and response.ok:
         if event_dest_uri:
             sut.log(Result.PASS, '', '', event_dest_uri,
                     Assertion.SERV_SSE_OPEN_CREATES_EVENT_DEST,
@@ -837,8 +837,8 @@ def test_sse_open_creates_event_dest(sut: SystemUnderTest):
             response.close()
     else:
         msg = 'Open of SSE stream failed; unable to test this assertion'
-        sut.log(Result.NOT_TESTED, 'GET', response.status_code,
-                sut.server_sent_event_uri,
+        code = response.status_code if response is not None else ''
+        sut.log(Result.NOT_TESTED, 'GET', code, sut.server_sent_event_uri,
                 Assertion.SERV_SSE_OPEN_CREATES_EVENT_DEST, msg)
     return None, None
 

--- a/assertions/service_details.py
+++ b/assertions/service_details.py
@@ -608,10 +608,21 @@ def test_sse_unsuccessful_response(sut: SystemUnderTest):
                 Assertion.SERV_SSE_UNSUCCESSFUL_RESPONSE, msg)
         return
 
-    response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
-                               headers={'Accept': 'application/json'},
-                               stream=True)
-    if response.ok:
+    response = None
+    exc_name = ''
+    try:
+        response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
+                                   headers={'Accept': 'application/json'},
+                                   stream=True)
+    except Exception as e:
+        exc_name = e.__class__.__name__
+    if response is None:
+        msg = ('Caught %s while opening SSE stream with incorrect Accept '
+               'header of "application/json"; expected response with status '
+               'code of 400 or greater' % exc_name)
+        sut.log(Result.FAIL, 'GET', '', sut.server_sent_event_uri,
+                Assertion.SERV_SSE_UNSUCCESSFUL_RESPONSE, msg)
+    elif response.ok:
         msg = ('Response from GET request to URL %s was successful; unable to '
                'test this assertion' % sut.server_sent_event_uri)
         sut.log(Result.NOT_TESTED, 'GET', response.status_code,

--- a/assertions/service_requests.py
+++ b/assertions/service_requests.py
@@ -70,7 +70,13 @@ def test_accept_header(sut: SystemUnderTest):
     uri = sut.server_sent_event_uri
     header_values = ['text/event-stream', 'text/event-stream;charset=utf-8']
     if uri:
-        test_header(sut, header, header_values, uri, assertion, stream=True)
+        try:
+            test_header(sut, header, header_values, uri, assertion,
+                        stream=True)
+        except Exception as e:
+            msg = ('Caught %s while opening SSE stream with valid '
+                   '"text/event-stream" Accept headers' % e.__class__.__name__)
+            sut.log(Result.FAIL, 'GET', '', uri, assertion, msg)
 
 
 def test_authorization_header(sut: SystemUnderTest):

--- a/assertions/utils.py
+++ b/assertions/utils.py
@@ -112,9 +112,13 @@ def get_sse_stream(sut):
                         if '@odata.id' in m])
 
     if sut.server_sent_event_uri:
-        response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
-                                   stream=True)
-    if response.ok and sut.subscriptions_uri:
+        try:
+            response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
+                                       stream=True)
+        except Exception as e:
+            logging.debug('Caught %s while opening SSE stream' %
+                          e.__class__.__name__)
+    if response is not None and response.ok and sut.subscriptions_uri:
         # get the "after" set of EventDestination URIs
         r = sut.session.get(sut.rhost + sut.subscriptions_uri)
         if r.status_code == requests.codes.OK:

--- a/assertions/utils.py
+++ b/assertions/utils.py
@@ -103,37 +103,38 @@ def get_sse_stream(sut):
     response = None
     event_dest_uri = None
     subs = set()
-    # get the "before" set of EventDestination URIs
-    if sut.subscriptions_uri:
-        r = sut.session.get(sut.rhost + sut.subscriptions_uri)
-        if r.status_code == requests.codes.OK:
-            data = r.json()
-            subs = set([m.get('@odata.id') for m in data.get('Members', [])
-                        if '@odata.id' in m])
+    try:
+        # get the "before" set of EventDestination URIs
+        if sut.subscriptions_uri:
+            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
+            if r.status_code == requests.codes.OK:
+                data = r.json()
+                subs = set([m.get('@odata.id') for m in data.get('Members', [])
+                            if '@odata.id' in m])
 
-    if sut.server_sent_event_uri:
-        try:
+        if sut.server_sent_event_uri:
             response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
                                        stream=True)
-        except Exception as e:
-            logging.debug('Caught %s while opening SSE stream' %
-                          e.__class__.__name__)
-    if response is not None and response.ok and sut.subscriptions_uri:
-        # get the "after" set of EventDestination URIs
-        r = sut.session.get(sut.rhost + sut.subscriptions_uri)
-        if r.status_code == requests.codes.OK:
-            data = r.json()
-            new_subs = set([m.get('@odata.id') for m in data.get('Members', [])
-                            if '@odata.id' in m])
-            diff = new_subs.difference(subs)
-            if len(diff) == 1:
-                event_dest_uri = diff.pop()
-            elif len(diff) == 0:
-                logging.debug('No EventDestination resource created when SSE '
-                              'stream opened')
-            else:
-                logging.debug('More than one (%s) EventDestination resources '
-                              'created when SSE stream opened' % len(diff))
+        if response is not None and response.ok and sut.subscriptions_uri:
+            # get the "after" set of EventDestination URIs
+            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
+            if r.status_code == requests.codes.OK:
+                data = r.json()
+                new_subs = set([m.get('@odata.id') for m in
+                                data.get('Members', []) if '@odata.id' in m])
+                diff = new_subs.difference(subs)
+                if len(diff) == 1:
+                    event_dest_uri = diff.pop()
+                elif len(diff) == 0:
+                    logging.debug('No EventDestination resource created when '
+                                  'SSE stream opened')
+                else:
+                    logging.debug('More than one (%s) EventDestination '
+                                  'resources created when SSE stream opened'
+                                  % len(diff))
+    except Exception as e:
+        logging.warning('Caught %s while opening SSE stream and getting '
+                        'EventDestination URI' % e.__class__.__name__)
     return response, event_dest_uri
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ aenum
 colorama
 pyasn1
 pyasn1-modules
-requests
+requests>=2.23.0
 sseclient-py
 urllib3


### PR DESCRIPTION
Based on feedback from issue #9, adding some try/except blocks around code that tries to trigger an HTTP redirect and code that opens the Server-Sent Events stream.

The PR also adds a version requirement to the requests package (>=2.23.0) to ensure a recent version is used. (The Protocol-Validator was developed and tested using version 2.23.0).

Fixes #9 