### PR TITLE
Add python 3.9 to tox unit tests and Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 - '3.6'
 - '3.7'
 - '3.8'
-- '3.8-dev'
+- '3.9'
 before_install:
 - pip install -U pip
 - pip install -U setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,pep8
+envlist = py35,py36,py37,py38,py39,pep8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Add Python 3.9 to the tox and Travis configs so that unit tests are run with 3.9.