### PR TITLE
Update unit tests to cover new try/except blocks

### DIFF
--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -647,7 +647,7 @@ def test_session_termination_side_effects(sut: SystemUnderTest):
         if response is None:
             msg = ('Caught %s while opening SSE stream; unable to test this '
                    'assertion' % exc_name)
-            sut.log(Result.NOT_TESTED, 'GET', '', new_session_uri,
+            sut.log(Result.NOT_TESTED, 'GET', '', sut.server_sent_event_uri,
                     Assertion.SEC_SESSION_TERMINATION_SIDE_EFFECTS, msg)
         elif response.ok:
             # delete the session

--- a/unittests/test_accounts.py
+++ b/unittests/test_accounts.py
@@ -116,6 +116,20 @@ class Accounts(TestCase):
         self.assertTrue(user.startswith('rfpv'))
         self.assertEqual(uri, self.account_uri3)
 
+    def test_add_account_via_patch_enable(self):
+        etag = '0123456789abcdef'
+        self.session.get.return_value.status_code = requests.codes.OK
+        self.session.get.return_value.ok = True
+        self.session.get.return_value.json.return_value = {'Enabled': False}
+        self.session.get.return_value.headers = {'ETag': etag}
+        self.session.post.return_value.status_code = (
+            requests.codes.METHOD_NOT_ALLOWED)
+        self.session.patch.return_value.status_code = requests.codes.OK
+        user, pwd, uri = accounts.add_account(self.sut, self.session)
+        self.session.patch.assert_called_with(
+            self.sut.rhost + self.account_uri3, json={'Enabled': True},
+            headers={'If-Match': etag})
+
     @mock.patch('assertions.accounts.logging.error')
     def test_add_account_via_patch_fail1(self, mock_logging_error):
         payload = {'UserName': 'alice', 'Enabled': True}

--- a/unittests/test_service_details.py
+++ b/unittests/test_service_details.py
@@ -825,6 +825,15 @@ class ServiceDetails(TestCase):
         self.assertIn('Response from GET request to URL %s was not successful'
                       % self.sse_uri, result['msg'])
 
+    @mock.patch('assertions.utils.logging.warning')
+    def test_test_sse_successful_response_exception(self, mock_warn):
+        self.sut.set_server_sent_event_uri(self.sse_uri)
+        self.mock_session.get.side_effect = ConnectionError
+        service.test_sse_successful_response(self.sut)
+        args = mock_warn.call_args[0]
+        self.assertIn('Caught ConnectionError while opening SSE',
+                      args[0])
+
     def test_test_sse_successful_response_fail1(self):
         self.sut.set_server_sent_event_uri(self.sse_uri)
         get_resp = add_response(self.sut, self.sse_uri, 'GET',
@@ -1011,6 +1020,18 @@ class ServiceDetails(TestCase):
         self.assertIn('Property "code" is not a string', result['msg'])
         self.assertIn('Property "message" is not a string', result['msg'])
         self.assertIn('Property "@Message.ExtendedInfo" is not a list',
+                      result['msg'])
+
+    def test_test_sse_unsuccessful_response_exception(self):
+        self.sut.set_server_sent_event_uri(self.sse_uri)
+        self.mock_session.get.side_effect = ConnectionError
+        service.test_sse_unsuccessful_response(self.sut)
+        result = get_result(
+            self.sut, Assertion.SERV_SSE_UNSUCCESSFUL_RESPONSE,
+            'GET', self.sse_uri)
+        self.assertIsNotNone(result)
+        self.assertEqual(Result.FAIL, result['result'])
+        self.assertIn('Caught ConnectionError while opening SSE',
                       result['msg'])
 
     def test_test_sse_unsuccessful_response_pass(self):


### PR DESCRIPTION
In PR #13, I added several `try/except` blocks around operations that could get a connection error, timeout, etc.

In this PR, I updated the unit tests to test those cases and get the test coverage back up to 100%.

One of the new unit tests uncovered a small issue where one report entry referenced the wrong URI. I fixed that in this PR as well.
