### PR TITLE
Fix socket connect() call to use hostname instead of netloc

### DIFF
--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -119,9 +119,9 @@ def test_certs_conform_to_x509v3(sut: SystemUnderTest):
             context.check_hostname = False
             context.verify_mode = ssl.CERT_NONE
             conn = context.wrap_socket(socket.socket(socket.AF_INET),
-                                       server_hostname=rhost.netloc)
+                                       server_hostname=rhost.hostname)
             port = 443 if rhost.port is None else rhost.port
-            conn.connect((rhost.netloc, port))
+            conn.connect((rhost.hostname, port))
             bin_cert = conn.getpeercert(binary_form=True)
             cert = decoder.decode(bin_cert, asn1Spec=rfc5280.Certificate())[0]
         except Exception as e:

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -349,11 +349,14 @@ class SecurityDetails(TestCase):
                 }
             }
         ]
+        mock_conn = mock.Mock()
+        self.mock_ssl_ctx.return_value.wrap_socket.return_value = mock_conn
         sec.test_certs_conform_to_x509v3(self.sut)
         result = get_result(self.sut, Assertion.SEC_CERTS_CONFORM_X509V3,
                             '', '')
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
+        mock_conn.connect.assert_called_once_with(('127.0.0.1', 8000))
 
     def test_test_certs_conform_to_x509v3_fail(self):
         # duck typing the decode result; it's not really array of dict()


### PR DESCRIPTION
In the X509v3 cert validation code, there is a socket `connect()` call that should take a tuple parameter of `(hostname, port)`.

But it was using the `netloc` value from the parsed `rhost` when it should have been using the `hostname` value.  The result was that if the `rhost` included an explicit port (e.g. `https://127.0.0.1:8000`), the tuple passed to the connect() call would be `('127.0.0.1:8000', 8000)` instead of `('127.0.0.1', 8000)`.

This PR updates the `test_certs_conform_to_x509v3()` function in `security_details.py` to use `hostname` instead of `netloc`. The unit test for that function is also updated to assert that the correct tuple value is passed to the `connect()` call.

Fixes #15 