### PR TITLE
Removed message check when an unsupported query parameter is provided

### DIFF
--- a/assertions/service_requests.py
+++ b/assertions/service_requests.py
@@ -526,6 +526,10 @@ def test_query_ignore_unsupported(sut: SystemUnderTest):
 def test_query_unsupported_dollar_params_ext_error(
         sut: SystemUnderTest, uri, response):
     """Perform tests for Assertion.REQ_QUERY_UNSUPPORTED_PARAMS_EXT_ERROR."""
+
+    # Removing test for now; there are no standard messages that allow a service to specify the query parameter not supported
+
+    """
     if ('application/json' in response.headers.get('Content-Type', '') and
             '@Message.ExtendedInfo' in response.text):
         data = response.json()
@@ -546,7 +550,7 @@ def test_query_unsupported_dollar_params_ext_error(
         sut.log(Result.FAIL, 'GET', response.status_code, uri,
                 Assertion.REQ_QUERY_UNSUPPORTED_PARAMS_EXT_ERROR,
                 msg)
-
+    """
 
 def test_query_unsupported_dollar_params(sut: SystemUnderTest):
     """Perform tests for Assertion.REQ_QUERY_UNSUPPORTED_DOLLAR_PARAMS."""

--- a/unittests/test_service_requests.py
+++ b/unittests/test_service_requests.py
@@ -797,11 +797,13 @@ class ServiceRequests(TestCase):
             'GET', uri)
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
+        """
         result = get_result(
             self.sut, Assertion.REQ_QUERY_UNSUPPORTED_PARAMS_EXT_ERROR,
             'GET', uri)
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
+        """
 
     def test_test_query_unsupported_dollar_params_mixed1(self):
         uri = '/redfish/v1/?$rpvunknown'
@@ -815,6 +817,7 @@ class ServiceRequests(TestCase):
             'GET', uri)
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
+        """
         result = get_result(
             self.sut, Assertion.REQ_QUERY_UNSUPPORTED_PARAMS_EXT_ERROR,
             'GET', uri)
@@ -822,6 +825,7 @@ class ServiceRequests(TestCase):
         self.assertEqual(Result.FAIL, result['result'])
         self.assertIn('The response did not contain an extended error',
                       result['msg'])
+        """
 
     def test_test_query_unsupported_dollar_params_mixed2(self):
         uri = '/redfish/v1/?$rpvunknown'
@@ -837,6 +841,7 @@ class ServiceRequests(TestCase):
             'GET', uri)
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
+        """
         result = get_result(
             self.sut, Assertion.REQ_QUERY_UNSUPPORTED_PARAMS_EXT_ERROR,
             'GET', uri)
@@ -844,6 +849,7 @@ class ServiceRequests(TestCase):
         self.assertEqual(Result.FAIL, result['result'])
         self.assertIn('The response contained an extended error, but the '
                       'unsupported query parameter', result['msg'])
+        """
 
     def test_test_query_invalid_values_not_tested(self):
         self.sut.set_supported_query_params({})


### PR DESCRIPTION
Fix #23 