### PR TITLE
Modified ETag testing to not assume previous ETags are now invalid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Update version numbers
       run: |
         sed -i -E 's/tool_version = .+/tool_version = '\'${{github.event.inputs.version}}\''/' rf_protocol_validator.py
+        sed -i -E 's/    version=.+,/    version="'${{github.event.inputs.version}}'",/' setup.py
     - name: Update the changelog
       run: |
         ex CHANGELOG.md <<eof
@@ -70,7 +71,31 @@ jobs:
         git commit -s -m "${{github.event.inputs.version}} versioning"
         git push origin master
     - name: Make the release
+      id: create_release
+      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      with:
+        tag_name: ${{github.event.inputs.version}}
+        release_name: ${{github.event.inputs.version}}
+        body: |
+          Changes since last release:
+          
+          ${{env.CHANGES}}
+        draft: false
+        prerelease: false
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
       run: |
-        gh release create ${{github.event.inputs.version}} -t ${{github.event.inputs.version}} -n "Changes since last release:"$'\n\n'"$CHANGES"
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish to pypi
+      env:
+        TWINE_USERNAME: ${{secrets.PYPI_USERNAME}}
+        TWINE_PASSWORD: ${{secrets.PYPI_PASSWORD}}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -8,9 +8,16 @@ The Redfish Protocol Validator tests the HTTP protocol behavior of a Redfish ser
 
 ## Installation
 
-The Redfish Protocol Validator can be installed by cloning the Git repository:
+From PyPI:
+
+    pip install redfish_protocol_validator
+
+From GitHub:
 
     git clone https://github.com/DMTF/Redfish-Protocol-Validator.git
+    cd Redfish-Protocol-Validator
+    python setup.py sdist
+    pip install dist/redfish_protocol_validator-x.x.x.tar.gz
 
 ## Requirements
 
@@ -28,7 +35,7 @@ sseclient-py
 urllib3
 ```
 
-You may install the external packages by running:
+If installing from GitHub, you may install the external packages by running:
 
     pip install -r requirements.txt
 
@@ -70,9 +77,9 @@ optional arguments:
 
 Example:
 
-    python rf_protocol_validator.py -r https://192.168.1.100 -u USERNAME -p PASSWORD
+    rf_protocol_validator.py -r https://192.168.1.100 -u USERNAME -p PASSWORD
 
-## Unit tests
+## Unit Tests
 
 The Redfish Protocol Validator unit tests are executed using the `tox` package.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright 2020-2022 DMTF. All rights reserved.
 
 ## About
 
-The Redfish Protocol Validator tests the HTTP protocol behavior of a Redfish service to validate that it conforms to the Redfish specification.
+The Redfish Protocol Validator tests the HTTP protocol behavior of a Redfish service to validate that it conforms to the Redfish Specification.
 
 ## Installation
 
@@ -51,14 +51,16 @@ usage: rf_protocol_validator.py [-h] [--version] --user USER --password
 
 Validate the protocol conformance of a Redfish service
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --version             show program's version number and exit
+required arguments:
   --user USER, -u USER  the username for authentication
   --password PASSWORD, -p PASSWORD
                         the password for authentication
   --rhost RHOST, -r RHOST
                         address of the Redfish service (with scheme)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --version             show program's version number and exit
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         the logging level (default: WARNING)
   --report-dir REPORT_DIR

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ optional arguments:
                         the password for authentication
   --rhost RHOST, -r RHOST
                         address of the Redfish service (with scheme)
-  --log-level LOG_LEVEL
+  --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         the logging level (default: WARNING)
   --report-dir REPORT_DIR
                         the directory for generated report files (default:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redfish Protocol Validator
 
-Copyright 2020 DMTF. All rights reserved.
+Copyright 2020-2022 DMTF. All rights reserved.
 
 ## About
 
@@ -8,7 +8,9 @@ The Redfish Protocol Validator tests the HTTP protocol behavior of a Redfish ser
 
 ## Installation
 
-`git clone https://github.com/DMTF/Redfish-Protocol-Validator.git`
+The Redfish Protocol Validator can be installed by cloning the Git repository:
+
+    git clone https://github.com/DMTF/Redfish-Protocol-Validator.git
 
 ## Requirements
 
@@ -28,7 +30,7 @@ urllib3
 
 You may install the external packages by running:
 
-`pip install -r requirements.txt`
+    pip install -r requirements.txt
 
 ## Usage
 
@@ -66,19 +68,21 @@ optional arguments:
                         the file or directory containing trusted CAs
 ```
 
-Example: `python rf_protocol_validator.py -r https://192.168.1.100 -u USERNAME -p PASSWORD`
+Example:
+
+    python rf_protocol_validator.py -r https://192.168.1.100 -u USERNAME -p PASSWORD
 
 ## Unit tests
 
-The Redfish-Protocol-Validator unit tests are executed using the `tox` package.
+The Redfish Protocol Validator unit tests are executed using the `tox` package.
 
 You may install `tox` by running:
 
-`pip install tox`
+    pip install tox
 
 Running the unit tests:
 
-`tox`
+    tox
 
 ## Release Process
 

--- a/assertions/accounts.py
+++ b/assertions/accounts.py
@@ -255,17 +255,15 @@ def patch_account(sut: SystemUnderTest, session, acct_uri,
                      resource_type=ResourceType.MANAGER_ACCOUNT,
                      request_type=request_type)
     if request_type == RequestType.NORMAL and 'If-Match' in headers:
-        # patch with previous ETag, which should fail
+        # patch with invalid ETag, which should fail
         pwd = new_password(sut)
         payload = {'Password': pwd}
         new_headers = utils.get_etag_header(sut, session, acct_uri)
+        bad_headers = {'If-Match': new_headers['If-Match'] + 'foobar'}
         r = session.patch(sut.rhost + acct_uri, json=payload,
-                          headers=headers)
+                          headers=bad_headers)
         if r.ok:
             new_pwd = pwd
-        logging.debug('PATCH %s: Before password change ETag is %s; after '
-                      'change ETag is %s' % (acct_uri, headers.get('If-Match'),
-                                             new_headers.get('If-Match')))
         sut.add_response(acct_uri, r,
                          resource_type=ResourceType.MANAGER_ACCOUNT,
                          request_type=RequestType.BAD_ETAG)

--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -734,7 +734,7 @@ def test_accounts_support_etags(sut: SystemUnderTest):
                         response.status_code, uri,
                         Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS, msg)
     if not found_response:
-        msg = ('No PATCH request to account resource with stale If-Match '
+        msg = ('No PATCH request to account resource with invalid If-Match '
                'header found; unable to test this assertion')
         sut.log(Result.NOT_TESTED, 'PATCH', '', '',
                 Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS, msg)

--- a/assertions/security_details.py
+++ b/assertions/security_details.py
@@ -711,7 +711,7 @@ def test_accounts_support_etags(sut: SystemUnderTest):
     for uri, response in responses.items():
         found_response = True
         if response.ok:
-            msg = ('%s request to account URI %s with stale If-Match header '
+            msg = ('%s request to account URI %s with invalid If-Match header '
                    'succeeded; expected it to fail with status %s'
                    % (response.request.method, uri,
                       requests.codes.PRECONDITION_FAILED))
@@ -724,7 +724,7 @@ def test_accounts_support_etags(sut: SystemUnderTest):
                         response.status_code, uri,
                         Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS, 'Test passed')
             else:
-                msg = ('%s request to account URI %s with stale If-Match '
+                msg = ('%s request to account URI %s with invalid If-Match '
                        'header failed with status %s; expected it to fail '
                        'with status %s; extended error: %s' %
                        (response.request.method, uri, response.status_code,

--- a/redfish_protocol_validator/accounts.py
+++ b/redfish_protocol_validator/accounts.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import logging
 import random
@@ -10,9 +10,9 @@ from urllib.parse import urlparse
 
 import requests
 
-from assertions import utils
-from assertions.constants import RequestType, ResourceType
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import RequestType, ResourceType
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def get_user_names(sut: SystemUnderTest, session,

--- a/redfish_protocol_validator/constants.py
+++ b/redfish_protocol_validator/constants.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 from aenum import Enum, auto
 

--- a/redfish_protocol_validator/protocol_details.py
+++ b/redfish_protocol_validator/protocol_details.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import re
 import xml.etree.ElementTree as ET
@@ -9,9 +9,9 @@ from urllib.parse import urlparse
 
 import requests
 
-from assertions import utils
-from assertions.constants import Assertion, ResourceType, Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Assertion, ResourceType, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 safe_chars_regex = re.compile(
     r"^([A-Za-z0-9!$&'()*+,\-./:;=@_]|%[A-Fa-f0-9]{2})*\Z")

--- a/redfish_protocol_validator/redfish_logo.py
+++ b/redfish_protocol_validator/redfish_logo.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 """
 Redfish Logo

--- a/redfish_protocol_validator/report.py
+++ b/redfish_protocol_validator/report.py
@@ -1,15 +1,15 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import html as html_mod
 import json
 from datetime import datetime
 
-from assertions import redfish_logo
-from assertions.constants import Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import redfish_logo
+from redfish_protocol_validator.constants import Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 html_template = """
 <html>

--- a/redfish_protocol_validator/resources.py
+++ b/redfish_protocol_validator/resources.py
@@ -1,18 +1,18 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import logging
 import random
 
 import requests
 
-from assertions import accounts as acct
-from assertions import sessions
-from assertions import utils
-from assertions.constants import RequestType, ResourceType
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import accounts as acct
+from redfish_protocol_validator import sessions
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import RequestType, ResourceType
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def set_mfr_model_fw(sut: SystemUnderTest, data):

--- a/redfish_protocol_validator/security_details.py
+++ b/redfish_protocol_validator/security_details.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 from base64 import b64decode
 import socket
@@ -14,10 +14,10 @@ from pyasn1_modules import rfc5280
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 
-from assertions import sessions
-from assertions import utils
-from assertions.constants import Assertion, RequestType, ResourceType, Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import sessions
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Assertion, RequestType, ResourceType, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 class Tls11HttpAdapter(HTTPAdapter):

--- a/redfish_protocol_validator/service_details.py
+++ b/redfish_protocol_validator/service_details.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import json
 import time
@@ -9,10 +9,10 @@ from urllib.parse import urlparse
 
 import requests
 
-from assertions import utils
-from assertions.constants import Assertion, RequestType, Result
-from assertions.constants import SSDP_ALL, SSDP_REDFISH
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Assertion, RequestType, Result
+from redfish_protocol_validator.constants import SSDP_ALL, SSDP_REDFISH
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def test_event_service_subscription(sut: SystemUnderTest):

--- a/redfish_protocol_validator/service_requests.py
+++ b/redfish_protocol_validator/service_requests.py
@@ -1,16 +1,16 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import logging
 from urllib.parse import urlparse
 
 import requests
 
-from assertions import utils
-from assertions.constants import Assertion, RequestType, Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Assertion, RequestType, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def test_header(sut: SystemUnderTest, header, header_values, uri, assertion,

--- a/redfish_protocol_validator/service_responses.py
+++ b/redfish_protocol_validator/service_responses.py
@@ -1,16 +1,16 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import io
 import xml.etree.ElementTree as ET
 
 import requests
 
-from assertions import utils
-from assertions.constants import Assertion, RequestType, ResourceType, Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Assertion, RequestType, ResourceType, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def test_access_control_allow_origin_header(sut: SystemUnderTest):

--- a/redfish_protocol_validator/sessions.py
+++ b/redfish_protocol_validator/sessions.py
@@ -1,16 +1,16 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import logging
 from urllib.parse import urlparse
 
 import requests
 
-from assertions import accounts
-from assertions.constants import RequestType
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import accounts
+from redfish_protocol_validator.constants import RequestType
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def bad_login(sut: SystemUnderTest):

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -1,15 +1,15 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import logging
 from urllib.parse import urlparse
 
 import requests
 
-from assertions.utils import redfish_version_to_tuple
-from assertions.constants import RequestType, Result
+from redfish_protocol_validator.utils import redfish_version_to_tuple
+from redfish_protocol_validator.constants import RequestType, Result
 
 
 class SystemUnderTest(object):

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import http.client
 import io
@@ -16,7 +16,7 @@ import colorama
 import requests
 import sseclient
 
-from assertions.constants import Result, SSDP_REDFISH
+from redfish_protocol_validator.constants import Result, SSDP_REDFISH
 
 _color_map = {
         Result.PASS: (colorama.Fore.GREEN, colorama.Style.RESET_ALL),

--- a/rf_protocol_validator.py
+++ b/rf_protocol_validator.py
@@ -50,7 +50,8 @@ def main():
     parser.add_argument('--rhost', '-r', type=str, required=True,
                         help='address of the Redfish service (with scheme)')
     parser.add_argument('--log-level', type=str, default='WARNING',
-                        help='the logging level (default: WARNING)')
+                        help='the logging level (default: WARNING)',
+                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'])
     parser.add_argument('--report-dir', type=str, default='reports',
                         help='the directory for generated report files '
                              '(default: "reports")')

--- a/rf_protocol_validator.py
+++ b/rf_protocol_validator.py
@@ -1,7 +1,8 @@
+#! /usr/bin/python
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import argparse
 import logging
@@ -13,17 +14,17 @@ import requests
 from urllib3.exceptions import InsecureRequestWarning
 from http.client import HTTPConnection
 
-from assertions import protocol_details
-from assertions import report
-from assertions import resources
-from assertions import security_details
-from assertions import service_details
-from assertions import service_requests
-from assertions import service_responses
-from assertions import sessions
-from assertions import utils
-from assertions.constants import Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import protocol_details
+from redfish_protocol_validator import report
+from redfish_protocol_validator import resources
+from redfish_protocol_validator import security_details
+from redfish_protocol_validator import service_details
+from redfish_protocol_validator import service_requests
+from redfish_protocol_validator import service_responses
+from redfish_protocol_validator import sessions
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 tool_version = '1.1.0'
 

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,32 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 from setuptools import setup
+from codecs import open
+
+with open("README.md", "r", "utf-8") as f:
+    long_description = f.read()
 
 setup(
     name="redfish_protocol_validator",
-    version="0.9.0",
+    version="1.1.0",
     description="Redfish Protocol Validator",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="DMTF, https://www.dmtf.org/standards/feedback",
     license="BSD 3-clause \"New\" or \"Revised License\"",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Topic :: Communications"
     ],
     keywords="Redfish",
     url="https://github.com/DMTF/Redfish-Protocol-Validator",
-    packages=["assertions"],
+    packages=["redfish_protocol_validator"],
+    scripts=['rf_protocol_validator.py'],
     install_requires=["aenum", "colorama", "pyasn1", "pyasn1-modules",
-                      "requests", "sseclient-py", "urllib3"]
+                      "requests>=2.23.0", "sseclient-py", "urllib3"]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
 commands =
     nosetests \
     --with-timer \
-    --with-coverage --cover-erase --cover-package=assertions \
+    --with-coverage --cover-erase --cover-package=redfish_protocol_validator \
     --cover-inclusive --cover-tests --cover-html \
     --cover-html-dir=.cover {posargs}
 

--- a/unittests/test_accounts.py
+++ b/unittests/test_accounts.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import string
 import unittest
@@ -9,9 +9,9 @@ from unittest import mock, TestCase
 
 import requests
 
-from assertions import accounts
-from assertions.constants import ResourceType
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import accounts
+from redfish_protocol_validator.constants import ResourceType
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 from unittests.utils import add_response
 
 
@@ -64,7 +64,7 @@ class Accounts(TestCase):
         role = accounts.select_standard_role(self.sut, self.session)
         self.assertEqual(role, 'ReadOnly')
 
-    @mock.patch('assertions.accounts.logging.error')
+    @mock.patch('redfish_protocol_validator.accounts.logging.error')
     def test_select_standard_role_fail(self, mock_logging_error):
         payload = {'Id': 'Guest'}
         add_response(self.sut, self.role_uri1, json=payload,
@@ -130,7 +130,7 @@ class Accounts(TestCase):
             self.sut.rhost + self.account_uri3, json={'Enabled': True},
             headers={'If-Match': etag})
 
-    @mock.patch('assertions.accounts.logging.error')
+    @mock.patch('redfish_protocol_validator.accounts.logging.error')
     def test_add_account_via_patch_fail1(self, mock_logging_error):
         payload = {'UserName': 'alice', 'Enabled': True}
         add_response(self.sut, self.account_uri3, json=payload,
@@ -164,7 +164,7 @@ class Accounts(TestCase):
         self.assertTrue(user.startswith('rfpv'))
         self.assertEqual(uri, new_uri)
 
-    @mock.patch('assertions.accounts.logging.error')
+    @mock.patch('redfish_protocol_validator.accounts.logging.error')
     def test_add_account_no_collection(self, mock_logging_error):
         self.sut.set_nav_prop_uri('Accounts', None)
         user, pwd, uri = accounts.add_account(self.sut, self.session)
@@ -174,7 +174,7 @@ class Accounts(TestCase):
         args = mock_logging_error.call_args[0]
         self.assertIn('No accounts collection found', args[0])
 
-    @mock.patch('assertions.accounts.logging.error')
+    @mock.patch('redfish_protocol_validator.accounts.logging.error')
     def test_add_account_collection_get_fail(self, mock_logging_error):
         add_response(self.sut, self.accounts_uri, json={},
                      status_code=requests.codes.NOT_FOUND)
@@ -260,7 +260,7 @@ class Accounts(TestCase):
         self.assertEqual(self.session.delete.call_count, 1)
         self.assertEqual(self.session.patch.call_count, 1)
 
-    @mock.patch('assertions.accounts.logging.error')
+    @mock.patch('redfish_protocol_validator.accounts.logging.error')
     def test_delete_account_via_patch_bad_username(self, mock_logging_error):
         self.session.delete.return_value.status_code = (
             requests.codes.METHOD_NOT_ALLOWED)
@@ -273,7 +273,7 @@ class Accounts(TestCase):
         args = mock_logging_error.call_args[0]
         self.assertIn('did not match expected username', args[0])
 
-    @mock.patch('assertions.accounts.logging.error')
+    @mock.patch('redfish_protocol_validator.accounts.logging.error')
     def test_delete_account_via_patch_get_failed(self, mock_logging_error):
         self.session.delete.return_value.status_code = (
             requests.codes.METHOD_NOT_ALLOWED)
@@ -320,9 +320,9 @@ class Accounts(TestCase):
                                 self.account_uri1)
         self.assertEqual(self.session.patch.call_count, 1)
 
-    @mock.patch('assertions.accounts.requests.get')
-    @mock.patch('assertions.accounts.requests.post')
-    @mock.patch('assertions.accounts.requests.patch')
+    @mock.patch('redfish_protocol_validator.accounts.requests.get')
+    @mock.patch('redfish_protocol_validator.accounts.requests.post')
+    @mock.patch('redfish_protocol_validator.accounts.requests.patch')
     def test_password_change_required1(self, mock_patch, mock_post, mock_get):
         user = 'bob'
         pwd = 'xyzzy'
@@ -336,9 +336,9 @@ class Accounts(TestCase):
         self.assertEqual(mock_post.call_count, 1)
         self.assertEqual(mock_patch.call_count, 1)
 
-    @mock.patch('assertions.accounts.requests.get')
-    @mock.patch('assertions.accounts.requests.post')
-    @mock.patch('assertions.accounts.requests.patch')
+    @mock.patch('redfish_protocol_validator.accounts.requests.get')
+    @mock.patch('redfish_protocol_validator.accounts.requests.post')
+    @mock.patch('redfish_protocol_validator.accounts.requests.patch')
     def test_password_change_required2(self, mock_patch, mock_post, mock_get):
         user = 'bob'
         pwd = 'xyzzy'
@@ -361,9 +361,9 @@ class Accounts(TestCase):
         self.assertEqual(mock_post.call_count, 0)
         self.assertEqual(mock_patch.call_count, 0)
 
-    @mock.patch('assertions.accounts.requests.get')
-    @mock.patch('assertions.accounts.requests.post')
-    @mock.patch('assertions.accounts.requests.patch')
+    @mock.patch('redfish_protocol_validator.accounts.requests.get')
+    @mock.patch('redfish_protocol_validator.accounts.requests.post')
+    @mock.patch('redfish_protocol_validator.accounts.requests.patch')
     def test_password_change_required_no_prop(self, mock_patch, mock_post,
                                               mock_get):
         user = 'bob'

--- a/unittests/test_constants.py
+++ b/unittests/test_constants.py
@@ -1,12 +1,12 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import TestCase
 
-from assertions.constants import Assertion, ResourceType, Result
+from redfish_protocol_validator.constants import Assertion, ResourceType, Result
 
 
 class Constants(TestCase):

--- a/unittests/test_protocol_details.py
+++ b/unittests/test_protocol_details.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import string
 import unittest
@@ -9,9 +9,9 @@ from unittest import mock, TestCase
 
 import requests
 
-from assertions import protocol_details as proto
-from assertions.constants import Assertion, RequestType, ResourceType, Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import protocol_details as proto
+from redfish_protocol_validator.constants import Assertion, RequestType, ResourceType, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 from unittests.utils import add_response, get_result
 
 

--- a/unittests/test_report.py
+++ b/unittests/test_report.py
@@ -1,16 +1,16 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from datetime import datetime
 from pathlib import Path
 from unittest import mock, TestCase
 
-from assertions.constants import Assertion, Result
-from assertions.report import html_report, json_results, tsv_report
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator.constants import Assertion, Result
+from redfish_protocol_validator.report import html_report, json_results, tsv_report
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 class Report(TestCase):

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -1,16 +1,16 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
 
 import requests
 
-from assertions import resources
-from assertions.constants import RequestType
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import resources
+from redfish_protocol_validator.constants import RequestType
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 from unittests.utils import add_response
 
 
@@ -231,12 +231,12 @@ class Resources(TestCase):
         self.assertEqual(sut.manufacturer, 'Contoso')
         self.assertEqual(sut.model, 'Contoso 2001')
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.sessions.delete_session')
-    @mock.patch('assertions.accounts.add_account')
-    @mock.patch('assertions.accounts.patch_account')
-    @mock.patch('assertions.accounts.delete_account')
-    @mock.patch('assertions.accounts.password_change_required')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.sessions.delete_session')
+    @mock.patch('redfish_protocol_validator.accounts.add_account')
+    @mock.patch('redfish_protocol_validator.accounts.patch_account')
+    @mock.patch('redfish_protocol_validator.accounts.delete_account')
+    @mock.patch('redfish_protocol_validator.accounts.password_change_required')
     def test_data_modification_requests(self, mock_pwd_change, mock_del_acct,
                                         mock_patch_acct, mock_add_acct,
                                         mock_delete_session,
@@ -272,13 +272,13 @@ class Resources(TestCase):
         self.assertEqual(mock_del_acct.call_count, 2)
         self.assertEqual(mock_pwd_change.call_count, 1)
 
-    @mock.patch('assertions.sessions.logging.error')
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.sessions.delete_session')
-    @mock.patch('assertions.accounts.add_account')
-    @mock.patch('assertions.accounts.patch_account')
-    @mock.patch('assertions.accounts.delete_account')
-    @mock.patch('assertions.accounts.password_change_required')
+    @mock.patch('redfish_protocol_validator.sessions.logging.error')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.sessions.delete_session')
+    @mock.patch('redfish_protocol_validator.accounts.add_account')
+    @mock.patch('redfish_protocol_validator.accounts.patch_account')
+    @mock.patch('redfish_protocol_validator.accounts.delete_account')
+    @mock.patch('redfish_protocol_validator.accounts.password_change_required')
     def test_data_modification_requests_exception(
             self, mock_pwd_change, mock_del_acct, mock_patch_acct,
             mock_add_acct, mock_delete_session, mock_create_session,
@@ -317,11 +317,11 @@ class Resources(TestCase):
         args = mock_error.call_args[0]
         self.assertIn('Caught exception while creating or patching', args[0])
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.sessions.delete_session')
-    @mock.patch('assertions.accounts.add_account')
-    @mock.patch('assertions.accounts.patch_account')
-    @mock.patch('assertions.accounts.delete_account')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.sessions.delete_session')
+    @mock.patch('redfish_protocol_validator.accounts.add_account')
+    @mock.patch('redfish_protocol_validator.accounts.patch_account')
+    @mock.patch('redfish_protocol_validator.accounts.delete_account')
     def test_data_modification_requests_no_auth(
             self, mock_del_acct, mock_patch_acct, mock_add_acct,
             mock_delete_session, mock_create_session):
@@ -354,8 +354,8 @@ class Resources(TestCase):
             self.sut, self.session, user, acct_uri,
             request_type=RequestType.NORMAL)
 
-    @mock.patch('assertions.sessions.logging.error')
-    @mock.patch('assertions.accounts.add_account')
+    @mock.patch('redfish_protocol_validator.sessions.logging.error')
+    @mock.patch('redfish_protocol_validator.accounts.add_account')
     def test_patch_other_account_exception(
             self, mock_add_acct, mock_error):
         user = 'rfpvc91c'
@@ -376,7 +376,7 @@ class Resources(TestCase):
         self.session.request.called_once_with(
             'DELETE', self.sut.rhost + '/redfish/v1/')
 
-    @mock.patch('assertions.sessions.requests.get')
+    @mock.patch('redfish_protocol_validator.sessions.requests.get')
     def test_basic_auth_requests(self, mock_get):
         headers = {'OData-Version': '4.0'}
         mock_get.return_value.status_code = requests.codes.OK
@@ -389,7 +389,7 @@ class Resources(TestCase):
             'GET', request_type=RequestType.BASIC_AUTH)
         self.assertEqual(len(responses), 2)
 
-    @mock.patch('assertions.sessions.requests.get')
+    @mock.patch('redfish_protocol_validator.sessions.requests.get')
     def test_http_requests_https_scheme(self, mock_get):
         headers = {'OData-Version': '4.0'}
         if self.sut.scheme == 'https':
@@ -414,8 +414,8 @@ class Resources(TestCase):
             'GET', request_type=RequestType.HTTP_NO_AUTH)
         self.assertEqual(len(responses), 2)
 
-    @mock.patch('assertions.resources.logging.warning')
-    @mock.patch('assertions.resources.requests.get')
+    @mock.patch('redfish_protocol_validator.resources.logging.warning')
+    @mock.patch('redfish_protocol_validator.resources.requests.get')
     def test_http_requests_https_scheme_exception(self, mock_get, mock_warn):
         mock_get.side_effect = ConnectionError
         mock_sut = mock.MagicMock(spec=SystemUnderTest)
@@ -426,7 +426,7 @@ class Resources(TestCase):
         self.assertIn('Caught ConnectionError while trying to trigger',
                       args[0])
 
-    @mock.patch('assertions.sessions.requests.get')
+    @mock.patch('redfish_protocol_validator.sessions.requests.get')
     def test_http_requests_http_scheme(self, mock_get):
         sut = SystemUnderTest('http://127.0.0.1:8000', 'oper', 'xyzzy')
         sut.set_sessions_uri('/redfish/v1/SessionService/Sessions')
@@ -446,14 +446,14 @@ class Resources(TestCase):
             'GET', request_type=RequestType.HTTP_NO_AUTH)
         self.assertEqual(len(responses), 2)
 
-    @mock.patch('assertions.sessions.logging.warning')
+    @mock.patch('redfish_protocol_validator.sessions.logging.warning')
     def test_http_requests_other_scheme(self, mock_warning):
         sut = SystemUnderTest('ftp://127.0.0.1:8000', 'oper', 'xyzzy')
         resources.http_requests(sut)
         args = mock_warning.call_args[0]
         self.assertIn('Unexpected scheme (ftp)', args[0])
 
-    @mock.patch('assertions.sessions.requests.get')
+    @mock.patch('redfish_protocol_validator.sessions.requests.get')
     def test_bad_auth_requests(self, mock_get):
         request = mock.Mock(spec=requests.Request)
         request.method = 'GET'

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
@@ -9,9 +9,9 @@ from unittest import mock, TestCase
 import requests
 from requests.exceptions import SSLError
 
-from assertions import security_details as sec
-from assertions.constants import Assertion, Result, RequestType, ResourceType
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import security_details as sec
+from redfish_protocol_validator.constants import Assertion, Result, RequestType, ResourceType
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 from unittests.utils import add_response, get_result
 
 
@@ -24,21 +24,21 @@ class SecurityDetails(TestCase):
         self.account_uri = '/redfish/v1/AccountsService/Accounts/3'
         self.mock_session = mock.MagicMock(spec=requests.Session)
         self.sut._set_session(self.mock_session)
-        patch_post = mock.patch('assertions.security_details.requests.post')
+        patch_post = mock.patch('redfish_protocol_validator.security_details.requests.post')
         self.mock_post = patch_post.start()
         self.addCleanup(patch_post.stop)
-        patch_get = mock.patch('assertions.security_details.requests.get')
+        patch_get = mock.patch('redfish_protocol_validator.security_details.requests.get')
         self.mock_get = patch_get.start()
         self.addCleanup(patch_get.stop)
         patch_ssl_ctx = mock.patch(
-            'assertions.security_details.ssl.SSLContext')
+            'redfish_protocol_validator.security_details.ssl.SSLContext')
         self.mock_ssl_ctx = patch_ssl_ctx.start()
         self.addCleanup(patch_ssl_ctx.stop)
         patch_ssl_sock = mock.patch(
-            'assertions.security_details.ssl.SSLSocket')
+            'redfish_protocol_validator.security_details.ssl.SSLSocket')
         self.mock_ssl_sock = patch_ssl_sock.start()
         self.addCleanup(patch_ssl_sock.stop)
-        patch_decoder = mock.patch('assertions.security_details.decoder')
+        patch_decoder = mock.patch('redfish_protocol_validator.security_details.decoder')
         self.mock_decoder = patch_decoder.start()
         self.addCleanup(patch_decoder.stop)
         add_response(self.sut, self.sut.sessions_uri, 'GET', requests.codes.OK)
@@ -76,7 +76,7 @@ class SecurityDetails(TestCase):
                      'GET', requests.codes.OK,
                      res_type=ResourceType.MANAGER_ACCOUNT)
 
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_tls_1_1_pass(self, mock_session):
         mock_session.return_value.mount.return_value = None
         sec.test_tls_1_1(self.sut)
@@ -85,7 +85,7 @@ class SecurityDetails(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_tls_1_1_fail(self, mock_session):
         mock_session.return_value.mount.return_value = None
         mock_session.return_value.get.side_effect = SSLError
@@ -647,7 +647,7 @@ class SecurityDetails(TestCase):
         self.assertIn('Unexpected scheme (ftp)',
                       result['msg'])
 
-    @mock.patch('assertions.resources.requests.post')
+    @mock.patch('redfish_protocol_validator.resources.requests.post')
     def test_test_session_create_https_only_exception(self, mock_post):
         sut = SystemUnderTest('https://127.0.0.1:8000', 'oper', 'xyzzy')
         sut.set_sessions_uri('/redfish/v1/SessionService/Sessions')
@@ -669,7 +669,7 @@ class SecurityDetails(TestCase):
         self.assertEqual(Result.NOT_TESTED, result['result'])
         self.assertIn('No ServerSentEventUri available', result['msg'])
 
-    @mock.patch('assertions.sessions.requests.post')
+    @mock.patch('redfish_protocol_validator.sessions.requests.post')
     def test_test_session_termination_side_effects_not_tested2(
             self, mock_post):
         self.sut.set_server_sent_event_uri('/redfish/v1/EventService/SSE')
@@ -688,8 +688,8 @@ class SecurityDetails(TestCase):
         self.assertEqual(Result.NOT_TESTED, result['result'])
         self.assertIn('Failed to create session', result['msg'])
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_session_termination_side_effects_not_tested3(
             self, mock_session, mock_create_session):
         self.sut.set_server_sent_event_uri('/redfish/v1/EventService/SSE')
@@ -710,8 +710,8 @@ class SecurityDetails(TestCase):
         self.assertIn('Opening ServerSentEventUri %s failed' %
                       self.sut.server_sent_event_uri, result['msg'])
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_session_termination_side_effects_not_tested4(
             self, mock_session, mock_create_session):
         self.sut.set_server_sent_event_uri('/redfish/v1/EventService/SSE')
@@ -735,8 +735,8 @@ class SecurityDetails(TestCase):
         self.assertEqual(Result.NOT_TESTED, result['result'])
         self.assertIn('Deleting session %s failed' % sess_uri, result['msg'])
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_session_termination_side_effects_exception(
             self, mock_session, mock_create_session):
         self.sut.set_server_sent_event_uri('/redfish/v1/EventService/SSE')
@@ -753,8 +753,8 @@ class SecurityDetails(TestCase):
         self.assertIn('Caught ConnectionError while opening SSE',
                       result['msg'])
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_session_termination_side_effects_fail1(
             self, mock_session, mock_create_session):
         self.sut.set_server_sent_event_uri('/redfish/v1/EventService/SSE')
@@ -781,8 +781,8 @@ class SecurityDetails(TestCase):
                       'ServerSentEventUri stream %s after' %
                       self.sut.server_sent_event_uri, result['msg'])
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_session_termination_side_effects_fail2(
             self, mock_session, mock_create_session):
         self.sut.set_server_sent_event_uri('/redfish/v1/EventService/SSE')
@@ -808,8 +808,8 @@ class SecurityDetails(TestCase):
         self.assertIn('Unable to read from ServerSentEventUri stream %s after'
                       % self.sut.server_sent_event_uri, result['msg'])
 
-    @mock.patch('assertions.sessions.create_session')
-    @mock.patch('assertions.security_details.requests.Session')
+    @mock.patch('redfish_protocol_validator.sessions.create_session')
+    @mock.patch('redfish_protocol_validator.security_details.requests.Session')
     def test_test_session_termination_side_effects_pass(
             self, mock_session, mock_create_session):
         self.sut.set_server_sent_event_uri('/redfish/v1/EventService/SSE')

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -850,7 +850,7 @@ class SecurityDetails(TestCase):
                             'PATCH', '')
         self.assertIsNotNone(result)
         self.assertEqual(Result.NOT_TESTED, result['result'])
-        self.assertIn('No PATCH request to account resource with stale',
+        self.assertIn('No PATCH request to account resource with invalid',
                       result['msg'])
 
     def test_test_accounts_support_etags_warn(self):
@@ -878,7 +878,7 @@ class SecurityDetails(TestCase):
                             'PATCH', self.account_uri)
         self.assertIsNotNone(result)
         self.assertEqual(Result.FAIL, result['result'])
-        self.assertIn('URI %s with stale If-Match header succeeded' %
+        self.assertIn('URI %s with invalid If-Match header succeeded' %
                       self.account_uri, result['msg'])
 
     def test_test_password_change_required_pass(self):

--- a/unittests/test_service_details.py
+++ b/unittests/test_service_details.py
@@ -1,17 +1,17 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
 
 import requests
 
-from assertions import service_details as service
-from assertions.constants import Assertion, RequestType, Result, SSDP_ALL
-from assertions.constants import SSDP_REDFISH
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import service_details as service
+from redfish_protocol_validator.constants import Assertion, RequestType, Result, SSDP_ALL
+from redfish_protocol_validator.constants import SSDP_REDFISH
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 from unittests.utils import add_response, get_result
 
 
@@ -174,7 +174,7 @@ class ServiceDetails(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
-    @mock.patch('assertions.service_details.utils.discover_ssdp')
+    @mock.patch('redfish_protocol_validator.service_details.utils.discover_ssdp')
     def test_pre_ssdp(self, mock_discover_ssdp):
         self.sut.set_mgr_net_proto_uri(
             '/redfish/v1/Managers/BMC/NetworkProtocol')
@@ -263,7 +263,7 @@ class ServiceDetails(TestCase):
         self.assertIn('Attempt to disable SSDP failed',
                       result['msg'])
 
-    @mock.patch('assertions.service_details.utils.discover_ssdp')
+    @mock.patch('redfish_protocol_validator.service_details.utils.discover_ssdp')
     def test_test_ssdp_can_be_disabled_fail2(self, mock_discover_ssdp):
         services = {
             self.uuid: {'USN': 'uuid:%s' % self.uuid}
@@ -286,7 +286,7 @@ class ServiceDetails(TestCase):
         self.assertIn('Service responded to SSDP query after disabling SSDP',
                       result['msg'])
 
-    @mock.patch('assertions.service_details.utils.discover_ssdp')
+    @mock.patch('redfish_protocol_validator.service_details.utils.discover_ssdp')
     def test_test_ssdp_can_be_disabled_pass(self, mock_discover_ssdp):
         services = {
             self.uuid: {'USN': 'uuid:%s' % self.uuid}
@@ -825,7 +825,7 @@ class ServiceDetails(TestCase):
         self.assertIn('Response from GET request to URL %s was not successful'
                       % self.sse_uri, result['msg'])
 
-    @mock.patch('assertions.utils.logging.warning')
+    @mock.patch('redfish_protocol_validator.utils.logging.warning')
     def test_test_sse_successful_response_exception(self, mock_warn):
         self.sut.set_server_sent_event_uri(self.sse_uri)
         self.mock_session.get.side_effect = ConnectionError
@@ -1081,7 +1081,7 @@ class ServiceDetails(TestCase):
         self.assertIn('No ServerSentEvent events read',
                       result['msg'])
 
-    @mock.patch('assertions.utils.time.time')
+    @mock.patch('redfish_protocol_validator.utils.time.time')
     def test_test_sse_blank_lines_between_events_timeout(self, mock_time):
         sse_response = [
             b': stream keep-alive\n\n',
@@ -1191,7 +1191,7 @@ class ServiceDetails(TestCase):
         self.assertIn('No EventDestination URI found',
                       result['msg'])
 
-    @mock.patch('assertions.service_details.time.sleep')
+    @mock.patch('redfish_protocol_validator.service_details.time.sleep')
     def test_test_sse_event_dest_deleted_on_close_not_tested3(
             self, mock_sleep):
         response = mock.Mock()
@@ -1209,7 +1209,7 @@ class ServiceDetails(TestCase):
         self.assertIn('Unexpected status on GET to EventDestination resource',
                       result['msg'])
 
-    @mock.patch('assertions.service_details.time.sleep')
+    @mock.patch('redfish_protocol_validator.service_details.time.sleep')
     def test_test_sse_event_dest_deleted_on_close_fail(
             self, mock_sleep):
         response = mock.Mock()
@@ -1227,7 +1227,7 @@ class ServiceDetails(TestCase):
         self.assertIn('EventDestination resource not deleted',
                       result['msg'])
 
-    @mock.patch('assertions.service_details.time.sleep')
+    @mock.patch('redfish_protocol_validator.service_details.time.sleep')
     def test_test_sse_event_dest_deleted_on_close_pass(
             self, mock_sleep):
         response = mock.Mock()
@@ -1432,7 +1432,7 @@ class ServiceDetails(TestCase):
         self.assertIn('Delete of EventDestination resource %s failed' %
                       event_dest, result['msg'])
 
-    @mock.patch('assertions.service_details.time.sleep')
+    @mock.patch('redfish_protocol_validator.service_details.time.sleep')
     def test_test_sse_close_connection_if_event_dest_deleted_fail2(
             self, mock_sleep):
         event_dest = '/redfish/v1/EventService/Subscriptions/1'
@@ -1455,7 +1455,7 @@ class ServiceDetails(TestCase):
         self.assertIn('resource, the connection appears to still be open',
                       result['msg'])
 
-    @mock.patch('assertions.service_details.time.sleep')
+    @mock.patch('redfish_protocol_validator.service_details.time.sleep')
     def test_test_sse_close_connection_if_event_dest_deleted_pass(
             self, mock_sleep):
         event_dest = '/redfish/v1/EventService/Subscriptions/1'
@@ -1754,7 +1754,7 @@ class ServiceDetails(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
-    @mock.patch('assertions.service_details.utils.discover_ssdp')
+    @mock.patch('redfish_protocol_validator.service_details.utils.discover_ssdp')
     def test_test_service_details_cover(self, mock_discover_ssdp):
         service.test_service_details(self.sut)
 

--- a/unittests/test_service_requests.py
+++ b/unittests/test_service_requests.py
@@ -1,16 +1,16 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
 
 import requests
 
-from assertions import service_requests as req
-from assertions.system_under_test import SystemUnderTest
-from assertions.constants import Assertion, RequestType, Result
+from redfish_protocol_validator import service_requests as req
+from redfish_protocol_validator.system_under_test import SystemUnderTest
+from redfish_protocol_validator.constants import Assertion, RequestType, Result
 from unittests.utils import add_response, get_result
 
 
@@ -1515,7 +1515,7 @@ class ServiceRequests(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
-    @mock.patch('assertions.service_requests.logging.warning')
+    @mock.patch('redfish_protocol_validator.service_requests.logging.warning')
     def test_patch_array_restore_warning(self, mock_warning):
         uri = self.mgr_net_proto_uri
         response = add_response(self.sut, uri, 'PATCH',
@@ -1600,7 +1600,7 @@ class ServiceRequests(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_to_members_prop_fail(self, mock_post):
         uri = self.sut.sessions_uri + '/Members'
         response = add_response(self.sut, uri, 'POST',
@@ -1615,7 +1615,7 @@ class ServiceRequests(TestCase):
         self.assertIn('POST to Members property URI %s failed with status %s'
                       % (uri, requests.codes.NOT_FOUND), result['msg'])
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_to_members_prop_pass(self, mock_post):
         uri = self.sut.sessions_uri + '/Members'
         session_uri = '/redfish/v1/SessionService/Sessions/123'
@@ -1677,7 +1677,7 @@ class ServiceRequests(TestCase):
         self.assertEqual(Result.PASS, result['result'])
         self.assertIn('Test passed', result['msg'])
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_not_idempotent_not_tested1(self, mock_post):
         uri = self.sut.sessions_uri
         response = add_response(
@@ -1692,7 +1692,7 @@ class ServiceRequests(TestCase):
         self.assertIn('POST request to %s failed with status code %s' %
                       (uri, requests.codes.BAD_REQUEST), result['msg'])
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_not_idempotent_warn(self, mock_post):
         uri = self.sut.sessions_uri
         session_uri = '/redfish/v1/Sessions/123'
@@ -1714,7 +1714,7 @@ class ServiceRequests(TestCase):
             self.sut.rhost + session_uri)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_not_idempotent_not_tested2(self, mock_post):
         uri = self.sut.sessions_uri
         session_uri = '/redfish/v1/Sessions/123'
@@ -1737,7 +1737,7 @@ class ServiceRequests(TestCase):
             self.sut.rhost + session_uri)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_not_idempotent_fail(self, mock_post):
         uri = self.sut.sessions_uri
         session_uri = '/redfish/v1/Sessions/123'
@@ -1760,7 +1760,7 @@ class ServiceRequests(TestCase):
             self.sut.rhost + session_uri)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_not_idempotent_pass(self, mock_post):
         uri = self.sut.sessions_uri
         session_uri1 = '/redfish/v1/Sessions/123'
@@ -1858,7 +1858,7 @@ class ServiceRequests(TestCase):
         self.assertEqual(uri2, result['uri'])
         self.assertEqual(requests.codes.METHOD_NOT_ALLOWED, result['status'])
 
-    @mock.patch('assertions.service_requests.requests.post')
+    @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_service_requests_cover(self, mock_post):
         req.test_service_requests(self.sut)
 

--- a/unittests/test_service_responses.py
+++ b/unittests/test_service_responses.py
@@ -1,16 +1,16 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
 
 import requests
 
-from assertions import service_responses as resp
-from assertions.system_under_test import SystemUnderTest
-from assertions.constants import Assertion, RequestType, ResourceType, Result
+from redfish_protocol_validator import service_responses as resp
+from redfish_protocol_validator.system_under_test import SystemUnderTest
+from redfish_protocol_validator.constants import Assertion, RequestType, ResourceType, Result
 from unittests.utils import add_response, get_result
 
 

--- a/unittests/test_sessions.py
+++ b/unittests/test_sessions.py
@@ -1,15 +1,15 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
 
 import requests
 
-from assertions import sessions
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import sessions
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 class Sessions(TestCase):
@@ -21,7 +21,7 @@ class Sessions(TestCase):
             'OData-Version': '4.0'
         }
 
-    @mock.patch('assertions.sessions.requests.post')
+    @mock.patch('redfish_protocol_validator.sessions.requests.post')
     def test_bad_login(self, mock_post):
         post_resp = mock.Mock(spec=requests.Response)
         post_resp.status_code = requests.codes.BAD_REQUEST
@@ -32,7 +32,7 @@ class Sessions(TestCase):
         sessions.bad_login(self.sut)
         self.assertEqual(mock_post.call_count, 1)
 
-    @mock.patch('assertions.sessions.requests.post')
+    @mock.patch('redfish_protocol_validator.sessions.requests.post')
     def test_create_session(self, mock_post):
         token = '87a5cd20'
         url = 'http://127.0.0.1:8000/redfish/v1/sessions/1234'
@@ -45,8 +45,8 @@ class Sessions(TestCase):
         new_uri, _ = sessions.create_session(self.sut)
         self.assertEqual(uri, new_uri)
 
-    @mock.patch('assertions.sessions.requests.post')
-    @mock.patch('assertions.sessions.logging.warning')
+    @mock.patch('redfish_protocol_validator.sessions.requests.post')
+    @mock.patch('redfish_protocol_validator.sessions.logging.warning')
     def test_create_session_post_fail(self, mock_warning, mock_post):
         mock_post.return_value.status_code = requests.codes.BAD_REQUEST
         mock_post.return_value.ok = False
@@ -62,7 +62,7 @@ class Sessions(TestCase):
         sessions.delete_session(self.sut, session, uri)
         session.delete.assert_called_once_with(self.sut.rhost + uri)
 
-    @mock.patch('assertions.sessions.requests.Session')
+    @mock.patch('redfish_protocol_validator.sessions.requests.Session')
     def test_no_auth_session(self, mock_session):
         session = mock.Mock(spec=requests.Session)
         mock_session.return_value = session

--- a/unittests/test_sut.py
+++ b/unittests/test_sut.py
@@ -1,15 +1,15 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
 
 import requests
 
-from assertions.constants import Assertion, ResourceType, Result
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator.constants import Assertion, ResourceType, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 from unittests.utils import add_response
 
 
@@ -150,7 +150,7 @@ class Sut(TestCase):
         self.assertEqual(self.sut.privilege_registry_uri,
                          self.privilege_registry_uri)
 
-    @mock.patch('assertions.system_under_test.logging.error')
+    @mock.patch('redfish_protocol_validator.system_under_test.logging.error')
     def test_bad_nav_prop(self, mock_error):
         self.sut.set_nav_prop_uri('Foo', '/redfish/v1/Foo')
         self.assertEqual(mock_error.call_count, 1)
@@ -306,13 +306,13 @@ class Sut(TestCase):
         self.assertEqual(self.sut.summary_count(Result.WARN), 0)
         self.assertEqual(self.sut.summary_count(Result.NOT_TESTED), 0)
 
-    @mock.patch('assertions.system_under_test.requests.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
     def test_get_sessions_uri_default(self, mock_get):
         mock_get.return_value.status_code = requests.codes.OK
         uri = self.sut._get_sessions_uri(self.headers)
         self.assertEqual(uri, '/redfish/v1/SessionService/Sessions')
 
-    @mock.patch('assertions.system_under_test.requests.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
     def test_get_sessions_uri_via_links(self, mock_get):
         response = mock.Mock(spec=requests.Response)
         response.status_code = requests.codes.OK
@@ -327,7 +327,7 @@ class Sut(TestCase):
         uri = self.sut._get_sessions_uri(self.headers)
         self.assertEqual(uri, '/redfish/v1/Sessions')
 
-    @mock.patch('assertions.system_under_test.requests.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
     def test_get_sessions_uri_via_session_service(self, mock_get):
         response1 = mock.Mock(spec=requests.Response)
         response1.status_code = requests.codes.OK
@@ -347,9 +347,9 @@ class Sut(TestCase):
         uri = self.sut._get_sessions_uri(self.headers)
         self.assertEqual(uri, '/redfish/v1/Sessions')
 
-    @mock.patch('assertions.system_under_test.requests.get')
-    @mock.patch('assertions.system_under_test.requests.post')
-    @mock.patch('assertions.system_under_test.requests.Session')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.post')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.Session')
     def test_login(self, mock_session, mock_post, mock_get):
         mock_get.return_value.status_code = requests.codes.OK
         post_resp = mock.Mock(spec=requests.Response)
@@ -369,8 +369,8 @@ class Sut(TestCase):
                          '/redfish/v1/sessions/1234')
         self.assertEqual(self.sut.active_session_key, token)
 
-    @mock.patch('assertions.system_under_test.requests.get')
-    @mock.patch('assertions.system_under_test.requests.post')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.post')
     def test_login_basic_auth(self, mock_post, mock_get):
         mock_get.return_value.status_code = requests.codes.OK
         post_resp = mock.Mock(spec=requests.Response)
@@ -383,9 +383,9 @@ class Sut(TestCase):
         self.assertIsNone(self.sut.active_session_key)
         self.assertEqual(session.auth, (self.sut.username, self.sut.password))
 
-    @mock.patch('assertions.system_under_test.requests.get')
-    @mock.patch('assertions.system_under_test.requests.post')
-    @mock.patch('assertions.system_under_test.requests.Session')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.post')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.Session')
     def test_login_no_token_header(self, mock_session, mock_post, mock_get):
         mock_get.return_value.status_code = requests.codes.OK
         post_resp = mock.Mock(spec=requests.Response)
@@ -419,7 +419,7 @@ class Sut(TestCase):
         self.assertIsNone(self.sut.active_session_key)
         self.assertIsNone(self.sut.active_session_uri)
 
-    @mock.patch('assertions.system_under_test.logging.error')
+    @mock.patch('redfish_protocol_validator.system_under_test.logging.error')
     def test_logout_fail(self, mock_error):
         token = '87a5cd20'
         url = 'http://127.0.0.1:8000/redfish/v1/sessions/1234'

--- a/unittests/test_utils.py
+++ b/unittests/test_utils.py
@@ -1,7 +1,7 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import unittest
 from unittest import mock, TestCase
@@ -9,9 +9,9 @@ from unittest import mock, TestCase
 import colorama
 import requests
 
-from assertions import utils
-from assertions.constants import Assertion, Result, SSDP_REDFISH
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Assertion, Result, SSDP_REDFISH
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 class MyTimeout(OSError):
@@ -155,8 +155,8 @@ class Utils(TestCase):
         self.assertEqual(keys, set())
 
     @mock.patch('builtins.print')
-    @mock.patch('assertions.utils.colorama.init')
-    @mock.patch('assertions.utils.colorama.deinit')
+    @mock.patch('redfish_protocol_validator.utils.colorama.init')
+    @mock.patch('redfish_protocol_validator.utils.colorama.deinit')
     def test_print_summary_all_pass(self, mock_colorama_deinit,
                                     mock_colorama_init, mock_print):
         utils.print_summary(self.sut)
@@ -173,8 +173,8 @@ class Utils(TestCase):
         self.assertNotIn(colorama.Fore.YELLOW, args[0])
 
     @mock.patch('builtins.print')
-    @mock.patch('assertions.utils.colorama.init')
-    @mock.patch('assertions.utils.colorama.deinit')
+    @mock.patch('redfish_protocol_validator.utils.colorama.init')
+    @mock.patch('redfish_protocol_validator.utils.colorama.deinit')
     def test_print_summary_not_all_pass(self, mock_colorama_deinit,
                                         mock_colorama_init, mock_print):
         self.sut.log(Result.FAIL, 'GET', 200, '/redfish/v1/accounts/1',
@@ -242,8 +242,8 @@ class Utils(TestCase):
         self.assertEqual(256, utils.sanitize(256, minimum=1))
         pass
 
-    @mock.patch('assertions.utils.socket')
-    @mock.patch('assertions.utils.http.client')
+    @mock.patch('redfish_protocol_validator.utils.socket')
+    @mock.patch('redfish_protocol_validator.utils.http.client')
     def test_discover_ssdp_ipv4(self, mock_http_client, mock_socket):
         mock_sock = mock.Mock()
         mock_sock.recv.return_value = b'foo'
@@ -253,8 +253,8 @@ class Utils(TestCase):
         services = utils.discover_ssdp()
         self.assertEqual({}, services)
 
-    @mock.patch('assertions.utils.socket')
-    @mock.patch('assertions.utils.http.client')
+    @mock.patch('redfish_protocol_validator.utils.socket')
+    @mock.patch('redfish_protocol_validator.utils.http.client')
     def test_discover_ssdp_ipv6(self, mock_http_client, mock_socket):
         mock_sock = mock.Mock()
         mock_sock.recv.return_value = b'foo'
@@ -264,8 +264,8 @@ class Utils(TestCase):
         services = utils.discover_ssdp(protocol='ipv6')
         self.assertEqual({}, services)
 
-    @mock.patch('assertions.utils.socket')
-    @mock.patch('assertions.utils.http.client')
+    @mock.patch('redfish_protocol_validator.utils.socket')
+    @mock.patch('redfish_protocol_validator.utils.http.client')
     def test_discover_ssdp_iface(self, mock_http_client, mock_socket):
         mock_sock = mock.Mock()
         mock_sock.recv.return_value = b'foo'
@@ -275,8 +275,8 @@ class Utils(TestCase):
         services = utils.discover_ssdp(iface='eth0')
         self.assertEqual({}, services)
 
-    @mock.patch('assertions.utils.socket')
-    @mock.patch('assertions.utils.http.client')
+    @mock.patch('redfish_protocol_validator.utils.socket')
+    @mock.patch('redfish_protocol_validator.utils.http.client')
     def test_discover_ssdp_bad_proto(self, mock_http_client, mock_socket):
         mock_sock = mock.Mock()
         mock_sock.recv.return_value = b'foo'

--- a/unittests/utils.py
+++ b/unittests/utils.py
@@ -1,15 +1,15 @@
 # Copyright Notice:
-# Copyright 2020 DMTF. All rights reserved.
+# Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:
-#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
 
 import json as json_util
 from unittest import mock
 
 import requests
 
-from assertions.constants import RequestType, ResourceType
-from assertions.system_under_test import SystemUnderTest
+from redfish_protocol_validator.constants import RequestType, ResourceType
+from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def add_response(sut: SystemUnderTest, uri, method='GET',


### PR DESCRIPTION
Fix #42 

While ETags likely should change as a result of a PATCH operation, this may not necessarily be true based on specific ETag calculation done by a particular service. Ultimately the Redfish Spec is silent on this aspect.

Also made changes to move files around to prepare for publication via PyPI.