### PR TITLE
Make pip installation more friendly

### DIFF
--- a/redfish_protocol_validator/console_scripts.py
+++ b/redfish_protocol_validator/console_scripts.py
@@ -1,4 +1,3 @@
-#! /usr/bin/python
 # Copyright Notice:
 # Copyright 2020-2022 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link:

--- a/rf_protocol_validator.py
+++ b/rf_protocol_validator.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from redfish_protocol_validator.console_scripts import main
+
+if __name__ == '__main__':
+  main()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setup(
     keywords="Redfish",
     url="https://github.com/DMTF/Redfish-Protocol-Validator",
     packages=["redfish_protocol_validator"],
-    scripts=['rf_protocol_validator.py'],
+    entry_points={
+        'console_scripts': ['rf_protocol_validator=redfish_protocol_validator.console_scripts:main']
+    },
     install_requires=["aenum", "colorama", "pyasn1", "pyasn1-modules",
                       "requests>=2.23.0", "sseclient-py", "urllib3"]
 )


### PR DESCRIPTION
Lots of diff to effect this change (sorry for that) but the primary goal is so that users can run rf_protocol_validator from the command line as a normal command, without the .py.
Specific changes are detailed in the commit messages.