### PR TITLE
SSDP discover format not follow the HTTP1.1 spec

### DIFF
--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -293,7 +293,7 @@ def discover_ssdp(port=1900, ttl=2, response_time=3, iface=None,
         'Host: {}:{}\r\n'
         'Man: "ssdp:discover"\r\n'
         "ST: {}\r\n"
-        "MX: {}\r\n"
+        "MX: {}\r\n\r\n"
     ).format(mcast_ip, port, search_target, response_time)
     socket.setdefaulttimeout(response_time + 2)
 


### PR DESCRIPTION
5 Request
   A request message from a client to a server includes, within the
   first line of that message, the method to be applied to the resource,
   the identifier of the resource, and the protocol version in use.

        Request       = Request-Line              ; Section 5.1
                        *(( general-header        ; Section 4.5
                         | request-header         ; Section 5.3
                         | entity-header ) CRLF)  ; Section 7.1
                        CRLF
                        [ message-body ]          ; Section 4.3

Signed-off-by: Han Jiang - TW (HW 1) <hanj@supermicro.com.tw>