### PR TITLE
Tagged the DELETE request to service root as UNSUPPORTED_REQ to better isolate DELETE testing from when it's expected to succeed

### DIFF
--- a/redfish_protocol_validator/constants.py
+++ b/redfish_protocol_validator/constants.py
@@ -45,6 +45,7 @@ class RequestType(NoValue):
     PATCH_RO_RESOURCE = auto()
     PATCH_COLLECTION = auto()
     PATCH_ODATA_PROPS = auto()
+    UNSUPPORTED_REQ = auto()
 
 
 class Assertion(NoValue):

--- a/redfish_protocol_validator/protocol_details.py
+++ b/redfish_protocol_validator/protocol_details.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 import requests
 
 from redfish_protocol_validator import utils
-from redfish_protocol_validator.constants import Assertion, ResourceType, Result
+from redfish_protocol_validator.constants import Assertion, ResourceType, RequestType, Result
 from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 safe_chars_regex = re.compile(
@@ -204,11 +204,11 @@ def test_http_unsupported_methods(sut: SystemUnderTest):
     """Perform tests on unsupported HTTP methods."""
     # Test Assertion.PROTO_HTTP_UNSUPPORTED_METHODS
     uri = '/redfish/v1/'
-    response = sut.get_response('DELETE', uri)
+    response = sut.get_response('DELETE', uri, request_type=RequestType.UNSUPPORTED_REQ)
     if response is None:
         sut.log(Result.NOT_TESTED, 'DELETE', '', uri,
                 Assertion.PROTO_HTTP_UNSUPPORTED_METHODS,
-                'No response found for TRACE method request')
+                'No response found for DELETE method request')
     elif (response.status_code == requests.codes.METHOD_NOT_ALLOWED or
           response.status_code == requests.codes.NOT_IMPLEMENTED):
         sut.log(Result.PASS, 'DELETE', response.status_code, uri,

--- a/redfish_protocol_validator/resources.py
+++ b/redfish_protocol_validator/resources.py
@@ -372,7 +372,7 @@ def unsupported_requests(sut: SystemUnderTest):
     # DELETE on service root is never allowed
     uri = '/redfish/v1/'
     response = sut.session.request('DELETE', sut.rhost + uri)
-    sut.add_response(uri, response)
+    sut.add_response(uri, response, request_type=RequestType.UNSUPPORTED_REQ)
 
 
 def basic_auth_requests(sut: SystemUnderTest):

--- a/redfish_protocol_validator/service_responses.py
+++ b/redfish_protocol_validator/service_responses.py
@@ -83,7 +83,7 @@ def test_allow_header_method_not_allowed(sut: SystemUnderTest):
     """Perform tests for Assertion.RESP_HEADERS_ALLOW_METHOD_NOT_ALLOWED."""
     found_method_not_allowed = False
     for req_type in [RequestType.NORMAL, RequestType.PATCH_COLLECTION,
-                     RequestType.PATCH_RO_RESOURCE]:
+                     RequestType.PATCH_RO_RESOURCE, RequestType.UNSUPPORTED_REQ]:
         for uri, response in sut.get_all_responses(request_type=req_type):
             if response.status_code == requests.codes.METHOD_NOT_ALLOWED:
                 found_method_not_allowed = True

--- a/unittests/test_protocol_details.py
+++ b/unittests/test_protocol_details.py
@@ -333,7 +333,8 @@ class ProtocolDetails(TestCase):
 
     def test_test_http_unsupported_methods_pass1(self):
         add_response(self.sut, '/redfish/v1/', 'DELETE',
-                     requests.codes.METHOD_NOT_ALLOWED)
+                     requests.codes.METHOD_NOT_ALLOWED,
+                     request_type=RequestType.UNSUPPORTED_REQ)
         proto.test_http_unsupported_methods(self.sut)
         result = get_result(self.sut, Assertion.PROTO_HTTP_UNSUPPORTED_METHODS,
                             'DELETE', '/redfish/v1/')
@@ -342,7 +343,8 @@ class ProtocolDetails(TestCase):
 
     def test_test_http_unsupported_methods_pass2(self):
         add_response(self.sut, '/redfish/v1/', 'DELETE',
-                     requests.codes.NOT_IMPLEMENTED)
+                     requests.codes.NOT_IMPLEMENTED,
+                     request_type=RequestType.UNSUPPORTED_REQ)
         proto.test_http_unsupported_methods(self.sut)
         result = get_result(self.sut, Assertion.PROTO_HTTP_UNSUPPORTED_METHODS,
                             'DELETE', '/redfish/v1/')
@@ -351,7 +353,8 @@ class ProtocolDetails(TestCase):
 
     def test_test_http_unsupported_methods_fail(self):
         add_response(self.sut, '/redfish/v1/', 'DELETE',
-                     requests.codes.BAD_REQUEST)
+                     requests.codes.BAD_REQUEST,
+                     request_type=RequestType.UNSUPPORTED_REQ)
         proto.test_http_unsupported_methods(self.sut)
         result = get_result(self.sut, Assertion.PROTO_HTTP_UNSUPPORTED_METHODS,
                             'DELETE', '/redfish/v1/')

--- a/unittests/test_service_requests.py
+++ b/unittests/test_service_requests.py
@@ -1830,7 +1830,8 @@ class ServiceRequests(TestCase):
     def test_test_delete_non_deletable_resource_warn(self):
         uri = '/redfish/v1/SessionService/Sessions/123'
         add_response(self.sut, uri, 'DELETE',
-                     status_code=requests.codes.BAD_REQUEST)
+                     status_code=requests.codes.BAD_REQUEST,
+                     request_type=RequestType.UNSUPPORTED_REQ)
         req.test_delete_non_deletable_resource(self.sut)
         result = get_result(
             self.sut, Assertion.REQ_DELETE_NON_DELETABLE_RESOURCE,
@@ -1846,9 +1847,11 @@ class ServiceRequests(TestCase):
         uri1 = '/redfish/v1/SessionService/Sessions/123'
         uri2 = '/redfish/v1/SessionService/Sessions/456'
         add_response(self.sut, uri1, 'DELETE',
-                     status_code=requests.codes.BAD_REQUEST)
+                     status_code=requests.codes.BAD_REQUEST,
+                     request_type=RequestType.UNSUPPORTED_REQ)
         add_response(self.sut, uri2, 'DELETE',
-                     status_code=requests.codes.METHOD_NOT_ALLOWED)
+                     status_code=requests.codes.METHOD_NOT_ALLOWED,
+                     request_type=RequestType.UNSUPPORTED_REQ)
         req.test_delete_non_deletable_resource(self.sut)
         result = get_result(
             self.sut, Assertion.REQ_DELETE_NON_DELETABLE_RESOURCE,


### PR DESCRIPTION
This stems from an observation in the logic of the REQ_DELETE_METHOD_REQUIRED test where it doesn't have intelligence of the context of the DELETE request. DELETE is used on service root for other tests to ensure it's rejected properly. If no other DELETE operations are performed during the test, it will produce a false error.