### PR TITLE
Cleanup of TODOs

### DIFF
--- a/redfish_protocol_validator/constants.py
+++ b/redfish_protocol_validator/constants.py
@@ -405,42 +405,6 @@ class Assertion(NoValue):
         'error if the body of the request contains both RegistryPrefixes and '
         'MessageIds, and shall return the HTTP 400 Bad Request status code.'
     )
-    SERV_EVENT_PERSISTENT_ACROSS_RESTARTS = (
-        'Services shall retain subscriptions as persistent across service '
-        'restarts.'
-    )
-    SERV_EVENT_PUSH_ONLY_ON_SUBSCRIPTION = (
-        'Services shall not push events by using HTTP POST unless an event '
-        'subscription has been created.'
-    )
-    SERV_EVENT_PAYLOAD_SIZE_LIMIT = (
-        'Services shall not send a push event payload larger than 1 Mebibyte '
-        '(1 MiB). If there is more than 1 MiB worth of data to send the '
-        'service shall divide the payload on the nearest Event entry such '
-        'that the total payload transmitted to the client is less than 1 MiB.'
-    )
-    SERV_EVENT_METRIC_REPORT_FORMAT = (
-        'Metric report message objects sent to the specified client endpoint '
-        'shall contain the properties, as described in the Redfish '
-        'MetricReport schema.'
-    )
-    SERV_EVENT_OTHER_FORMAT = (
-        'Event message objects POSTed to the specified client endpoint shall '
-        'contain the properties as described in the Redfish Event schema.'
-    )
-    SERV_EVENT_MESSAGE_KEY_FORMAT = (
-        '[The MessageKey variable] shall not include spaces, periods, or '
-        'special characters.'
-    )
-    SERV_EVENT_OEM_NO_ADDITIONAL_MESSAGE_ARGS = (
-        'OEMs shall not supply additional message arguments beyond those in a '
-        'standard Message Registry.'
-    )
-    SERV_EVENT_OEM_NO_CHANGED_REGISTRY_VALUES = (
-        'OEMs may substitute their own Message Registry for the standard '
-        'registry to provide the OEM section within the registry but shall '
-        'not change the standard values, such as messages, in such registries.'
-    )
     SERV_SSDP_CAN_BE_DISABLED = (
         'Use of SSDP is optional, and if implemented, shall enable the user '
         'to disable the protocol through the ManagerNetworkProtocol resource.'
@@ -477,12 +441,6 @@ class Assertion(NoValue):
     SERV_SSDP_M_SEARCH_RESPONSE_FORMAT = (
         'The response to an M-SEARCH multicast or unicast query shall use '
         'the [example format shown].'
-    )
-    SERV_SSDP_DISABLE_ADDITIONAL_UPNP_MESSAGES = (
-        'If [additional UPnP-defined SSDP messages to announce their '
-        'availability to software are] implemented, services shall allow the '
-        'end user to disable the traffic separately from the M-SEARCH '
-        'response functionality.'
     )
     SERV_SSE_SUCCESSFUL_RESPONSE = (
         'Successful resource responses for SSE shall return the HTTP 200 OK '
@@ -606,11 +564,6 @@ class Assertion(NoValue):
     SEC_BASIC_AUTH_OVER_HTTPS = (
         'All requests that use HTTP Basic authentication shall require HTTPS.'
     )
-    SEC_CHANNEL_AUTH_HEADER = (
-        # TODO(bdodd): needs clarification in the spec
-        'An authentication header shall accompany every request that '
-        'establishes a secure channel.'
-    )
     SEC_REQUIRE_LOGIN_SESSIONS = (
         'Service shall provide login sessions that conform with this '
         'specification.'
@@ -662,10 +615,6 @@ class Assertion(NoValue):
         '@Message.ExtendedInfo object that contains the '
         'PasswordChangeRequired message from the Base Message Registry.'
     )
-    SEC_PRIV_EQUIVALENT_ROLES = (
-        # TODO(bdodd): Difficult; try to implement at a future date
-        'Two roles with the same privileges shall behave equivalently.'
-    )
     SEC_PRIV_ONE_ROLE_PRE_USER = (
         'Each user shall be assigned exactly one role.'
     )
@@ -681,21 +630,9 @@ class Assertion(NoValue):
         'A predefined role or a custom role shall be assigned to a user when '
         'a manager account is created.'
     )
-    SEC_PRIV_MODEL_SAME_FOR_ETAG_AND_ITS_DATA = (
-        # TODO(bdodd): Not sure how to test this
-        'Services shall enforce the same privilege model for ETag-related '
-        'activity as is enforced for the data being represented by the ETag.'
-    )
     SEC_PRIV_OPERATION_TO_PRIV_MAPPING = (
         'For every request that a client makes to a service, the service '
         'shall determine that the authenticated identity of the requester has '
         'the authorization to complete the requested operation on the '
         'resource in the request.'
-    )
-    SEC_PRIV_REDFISH_FORUM_PRIV_REGISTRY_DEF = (
-        # TODO(bdodd): See notes from Mike R. on testing
-        'If a service provides a Privilege Registry, the service shall use '
-        'the Redfish Forum\'s Privilege Registry definition as a base '
-        'operation-to-privilege mapping definition for operations that the '
-        'service supports to promote interoperability for Redfish clients.'
     )

--- a/redfish_protocol_validator/resources.py
+++ b/redfish_protocol_validator/resources.py
@@ -54,18 +54,6 @@ def find_certificates(sut: SystemUnderTest, data):
                             sut.add_cert(coll_uri, uri)
 
 
-def get_all_resources(sut: SystemUnderTest, uri='/redfish/v1/',
-                      uris=None):
-    # TODO(bdodd): walk entire service, yielding the resource GET responses
-    raise NotImplementedError
-
-
-def get_select_resources(sut: SystemUnderTest, uri='/redfish/v1/',
-                         uris=None):
-    # TODO(bdodd): fetch specified URIs, yielding the resource GET responses
-    raise NotImplementedError
-
-
 def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
                           uris=None):
     """

--- a/redfish_protocol_validator/security_details.py
+++ b/redfish_protocol_validator/security_details.py
@@ -443,12 +443,6 @@ def test_basic_auth_over_https(sut: SystemUnderTest):
                     Assertion.SEC_BASIC_AUTH_OVER_HTTPS, 'Test passed')
 
 
-def test_security_channel_auth_header(sut: SystemUnderTest):
-    """Perform test for Assertion.SEC_CHANNEL_AUTH_HEADER"""
-    # TODO(bdodd): needs clarification in the spec
-    pass
-
-
 def test_require_login_sessions(sut: SystemUnderTest):
     """Perform test for Assertion.SEC_REQUIRE_LOGIN_SESSIONS"""
     response = sut.get_response('POST', sut.sessions_uri)
@@ -876,12 +870,6 @@ def test_password_change_required(sut: SystemUnderTest):
                 Assertion.SEC_PWD_CHANGE_REQ_ALLOW_PATCH_PASSWORD, msg)
 
 
-def test_priv_equivalent_roles(sut: SystemUnderTest):
-    """Perform test for Assertion.SEC_PRIV_EQUIVALENT_ROLES."""
-    # TODO(bdodd): Difficult; try to implement at a future date
-    pass
-
-
 def test_priv_one_role_per_user(sut: SystemUnderTest):
     """Perform test for Assertion.SEC_PRIV_ONE_ROLE_PRE_USER."""
     for uri, response in sut.get_responses_by_method(
@@ -947,9 +935,9 @@ def test_priv_predefined_roles_not_modifiable(sut: SystemUnderTest):
     uri = None
     data = {}
     role = 'ReadOnly'
-    # TODO(bdodd): Add standard priv instead of made-up one? Or delete instead?
-    test_priv = 'RfProtoValTestPriv'
-    # locate ReadOnly role
+    test_priv = ['Login', 'ConfigureManager', 'ConfigureUsers',
+                 'ConfigureComponents', 'ConfigureSelf']
+    # locate the ReadOnly role
     for uri, response in sut.get_responses_by_method(
             'GET', resource_type=ResourceType.ROLE).items():
         if response.ok:
@@ -958,59 +946,36 @@ def test_priv_predefined_roles_not_modifiable(sut: SystemUnderTest):
                 read_only_found = True
                 break
     if read_only_found:
+        # Save the current privileges in case the PATCH is accepted
         privs = data.get('AssignedPrivileges')
-        if len(privs) and test_priv not in privs:
-            # build payload to add a new priv to AssignedPrivileges
-            new_privs = [{}] * len(privs)
-            if privs[-1] is None:
-                # rigid array type
-                for i in range(len(privs)):
-                    if privs[i] is None:
-                        new_privs[i] = test_priv
-                        break
-            else:
-                # variable or fixed array type
-                new_privs.append(test_priv)
-            payload = {'AssignedPrivileges': new_privs}
-            headers = utils.get_etag_header(sut, sut.session, uri)
-            # issue the PATCH
-            response = sut.session.patch(sut.rhost + uri, json=payload,
-                                         headers=headers)
-            if response.ok:
-                msg = ('PATCH request to %s to modify the AssignedPrivileges '
-                       'of predefined role %s succeeded with status %s; '
-                       'expected it to fail' %
-                       (uri, role, response.status_code))
-                sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
-                        Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
-                        msg)
-                # PATCH succeeded unexpectedly; try to PATCH it back
-                r = sut.session.get(sut.rhost + uri)
-                if r.ok:
-                    d = r.json()
-                    patched_privs = d.get('AssignedPrivileges')
-                    if test_priv in patched_privs:
-                        payload = {'AssignedPrivileges': privs}
-                        etag = r.headers.get('ETag')
-                        headers = {'If-Match': etag} if etag else {}
-                        sut.session.patch(
-                            sut.rhost + uri, json=payload, headers=headers)
-            else:
-                sut.log(Result.PASS, 'PATCH', response.status_code, uri,
-                        Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
-                        'Test passed')
-        else:
-            if len(privs):
-                msg = ('Test privilege %s already present in predefined role '
-                       '%s; unable to test this assertion' % (test_priv, role))
-            else:
-                msg = ('No AssignedPrivileges found in role %s; unable to '
-                       'test this assertion' % role)
-            sut.log(Result.NOT_TESTED, 'PATCH', '', uri,
+
+        # PATCH the test privileges
+        payload = {'AssignedPrivileges': test_priv}
+        headers = utils.get_etag_header(sut, sut.session, uri)
+        response = sut.session.patch(sut.rhost + uri, json=payload,
+                                     headers=headers)
+        if response.ok:
+            msg = ('PATCH request to %s to modify the AssignedPrivileges '
+                   'of predefined role %s succeeded with status %s; '
+                   'expected it to fail' %
+                   (uri, role, response.status_code))
+            sut.log(Result.FAIL, 'PATCH', response.status_code, uri,
                     Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
                     msg)
+            # PATCH succeeded unexpectedly; try to PATCH it back
+            r = sut.session.get(sut.rhost + uri)
+            if r.ok:
+                payload = {'AssignedPrivileges': privs}
+                etag = r.headers.get('ETag')
+                headers = {'If-Match': etag} if etag else {}
+                sut.session.patch(sut.rhost + uri, json=payload,
+                                  headers=headers)
+        else:
+            sut.log(Result.PASS, 'PATCH', response.status_code, uri,
+                    Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
+                    'Test passed')
     else:
-        msg = ('Redefined role %s not found; unable to test this assertion'
+        msg = ('Predefined role %s not found; unable to test this assertion'
                % role)
         sut.log(Result.NOT_TESTED, 'PATCH', '', '',
                 Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
@@ -1036,12 +1001,6 @@ def test_priv_roles_assigned_at_account_create(sut: SystemUnderTest):
                     sut.log(Result.FAIL, 'GET', response.status_code, uri,
                             Assertion.SEC_PRIV_ROLE_ASSIGNED_AT_ACCOUNT_CREATE,
                             msg)
-
-
-def test_priv_model_same_for_etag_and_its_data(sut: SystemUnderTest):
-    """Perform test for Assertion.SEC_PRIV_MODEL_SAME_FOR_ETAG_AND_ITS_DATA."""
-    # TODO(bdodd): Not sure how to test this
-    pass
 
 
 def test_priv_operation_to_priv_mapping(sut: SystemUnderTest):
@@ -1088,12 +1047,6 @@ def test_priv_operation_to_priv_mapping(sut: SystemUnderTest):
                 msg)
 
 
-def test_priv_redfish_forum_priv_regisistry_def(sut: SystemUnderTest):
-    """Perform test for Assertion.SEC_PRIV_REDFISH_FORUM_PRIV_REGISTRY_DEF."""
-    # TODO(bdodd): See notes from Mike R. on testing
-    pass
-
-
 def test_authentication(sut: SystemUnderTest):
     """Perform authentication tests"""
     test_basic_auth_standalone(sut)
@@ -1107,7 +1060,6 @@ def test_authentication(sut: SystemUnderTest):
     test_no_auth_cookies(sut)
     test_support_basic_auth(sut)
     test_basic_auth_over_https(sut)
-    test_security_channel_auth_header(sut)
     test_require_login_sessions(sut)
     test_sessions_uri_location(sut)
     test_session_post_response(sut)
@@ -1116,14 +1068,11 @@ def test_authentication(sut: SystemUnderTest):
     test_session_termination_side_effects(sut)
     test_accounts_support_etags(sut)
     test_password_change_required(sut)
-    test_priv_equivalent_roles(sut)
     test_priv_one_role_per_user(sut)
     test_priv_support_predefined_roles(sut)
     test_priv_predefined_roles_not_modifiable(sut)
     test_priv_roles_assigned_at_account_create(sut)
-    test_priv_model_same_for_etag_and_its_data(sut)
     test_priv_operation_to_priv_mapping(sut)
-    test_priv_redfish_forum_priv_regisistry_def(sut)
 
 
 def test_protocols(sut: SystemUnderTest):

--- a/redfish_protocol_validator/service_details.py
+++ b/redfish_protocol_validator/service_details.py
@@ -166,52 +166,6 @@ def test_event_error_on_mutually_excl_props(sut: SystemUnderTest):
                 Assertion.SERV_EVENT_ERROR_MUTUALLY_EXCL_PROPS, msg)
 
 
-def test_subscriptions_persistent_across_restart(sut: SystemUnderTest):
-    """Perform tests for Assertion.SERV_EVENT_PERSISTENT_ACROSS_RESTARTS."""
-    # TODO(bdodd): This may be difficult to implement in a way that does not
-    #  disrupt the tool since there will be side-effects like destroying
-    #  existing sessions.
-    pass
-
-
-def test_events_push_only_on_subscription(sut: SystemUnderTest):
-    """Perform tests for Assertion.SERV_EVENT_PUSH_ONLY_ON_SUBSCRIPTION."""
-    # TODO(bdodd): Testable?
-    pass
-
-
-def test_event_payload_size_limit(sut: SystemUnderTest):
-    """Perform tests for Assertion.SERV_EVENT_PAYLOAD_SIZE_LIMIT."""
-    pass
-
-
-def test_event_metric_report_format(sut: SystemUnderTest):
-    """Perform tests for Assertion.SERV_EVENT_METRIC_REPORT_FORMAT."""
-    pass
-
-
-def test_event_other_format(sut: SystemUnderTest):
-    """Perform tests for Assertion.SERV_EVENT_OTHER_FORMAT."""
-    pass
-
-
-def test_event_message_key_format(sut: SystemUnderTest):
-    """Perform tests for Assertion.SERV_EVENT_MESSAGE_KEY_FORMAT."""
-    pass
-
-
-def test_event_oem_no_additional_message_args(sut: SystemUnderTest):
-    """Perform tests for
-    Assertion.SERV_EVENT_OEM_NO_ADDITIONAL_MESSAGE_ARGS."""
-    pass
-
-
-def test_event_oem_no_changed_registry_values(sut: SystemUnderTest):
-    """Perform tests for
-    Assertion.SERV_EVENT_OEM_NO_CHANGED_REGISTRY_VALUES."""
-    pass
-
-
 def pre_ssdp(sut: SystemUnderTest):
     """Perform prerequisite SSDP steps"""
     # discover using the redfish search target
@@ -530,13 +484,6 @@ def test_ssdp_m_search_response_format(sut: SystemUnderTest):
     else:
         sut.log(Result.PASS, '', '', '',
                 Assertion.SERV_SSDP_M_SEARCH_RESPONSE_FORMAT, 'Test passed')
-
-
-def test_ssdp_disable_additional_upnp_messages(sut: SystemUnderTest):
-    """Perform tests for
-    Assertion.SERV_SSDP_DISABLE_ADDITIONAL_UPNP_MESSAGES."""
-    # TODO(bdodd): There doesn't seem to be a standard way to test this
-    pass
 
 
 def test_sse_successful_response(sut: SystemUnderTest):
@@ -1063,22 +1010,6 @@ def test_eventing(sut: SystemUnderTest):
     test_push_style_eventing(sut)
     test_event_error_on_bad_request(sut)
     test_event_error_on_mutually_excl_props(sut)
-    test_subscriptions_persistent_across_restart(sut)
-    test_events_push_only_on_subscription(sut)
-    test_event_payload_size_limit(sut)
-    test_event_metric_report_format(sut)
-    test_event_other_format(sut)
-    test_event_message_key_format(sut)
-    test_event_oem_no_additional_message_args(sut)
-    test_event_oem_no_changed_registry_values(sut)
-
-
-def test_asynchronous_ops(sut: SystemUnderTest):
-    """Perform asynchronous operation tests"""
-    # TODO(bdodd): At this time, there seems to be no async operation that
-    #     would be implemented by many vendors and be non-invasive to test.
-    #     Revisit in future.
-    pass
 
 
 def test_discovery(sut: SystemUnderTest):
@@ -1091,7 +1022,6 @@ def test_discovery(sut: SystemUnderTest):
     test_ssdp_st_header_format(sut)
     test_ssdp_al_header_points_to_service_root(sut)
     test_ssdp_m_search_response_format(sut)
-    test_ssdp_disable_additional_upnp_messages(sut)
 
 
 def test_server_sent_events(sut: SystemUnderTest):
@@ -1112,16 +1042,8 @@ def test_server_sent_events(sut: SystemUnderTest):
     test_sse_json_metric_report_format(sut, events)
 
 
-def test_update_service(sut: SystemUnderTest):
-    """Perform update service tests"""
-    # TODO(bdodd): Initiating an update not practical at this time
-    pass
-
-
 def test_service_details(sut: SystemUnderTest):
     """Perform tests from the 'Service details' section of the spec."""
     test_eventing(sut)
-    test_asynchronous_ops(sut)
     test_discovery(sut)
     test_server_sent_events(sut)
-    test_update_service(sut)

--- a/redfish_protocol_validator/service_requests.py
+++ b/redfish_protocol_validator/service_requests.py
@@ -1322,7 +1322,6 @@ def test_query_params(sut: SystemUnderTest):
         test_query_ignore_unsupported(sut)
         test_query_unsupported_dollar_params(sut)
         test_query_invalid_values(sut)
-        # TODO(bdodd): add assertions for $expand, $select, and $filter
 
 
 def test_head(sut: SystemUnderTest):
@@ -1382,17 +1381,6 @@ def test_post_action(sut: SystemUnderTest):
     # NOTE(bdodd): Actions better tested in the Redfish-Usecase-Checkers
 
 
-def test_operation_apply_time(sut: SystemUnderTest):
-    """Perform tests from the 'Operation apply time' sub-section of the
-    spec."""
-    # TODO(bdodd): Need an operation to test that will be minimally disruptive
-
-
-def test_deep_operations(sut: SystemUnderTest):
-    """Perform tests from the 'Deep operations' sub-section of the spec."""
-    # TODO(bdodd): These will be challenging to test; defer for now
-
-
 def test_service_requests(sut: SystemUnderTest):
     """Perform tests from the 'Service requests' section of the spec."""
     test_request_headers(sut)
@@ -1406,5 +1394,3 @@ def test_service_requests(sut: SystemUnderTest):
     test_post_create(sut)
     test_delete(sut)
     test_post_action(sut)
-    test_operation_apply_time(sut)
-    test_deep_operations(sut)

--- a/redfish_protocol_validator/service_responses.py
+++ b/redfish_protocol_validator/service_responses.py
@@ -13,12 +13,6 @@ from redfish_protocol_validator.constants import Assertion, RequestType, Resourc
 from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
-def test_access_control_allow_origin_header(sut: SystemUnderTest):
-    """Perform tests for Assertion.RESP_HEADERS_ACCESS_CONTROL_ALLOW_ORIGIN."""
-    # TODO(bdodd): How can we test this?
-    pass
-
-
 def test_header_present(sut: SystemUnderTest, header, uri, method, response,
                         assertion):
     """Test that header is present in the response."""
@@ -579,7 +573,6 @@ def test_odata_service_value_prop(sut: SystemUnderTest):
 
 def test_response_headers(sut: SystemUnderTest):
     """Perform tests from the 'Response headers' sub-section of the spec."""
-    test_access_control_allow_origin_header(sut)
     test_allow_header_method_not_allowed(sut)
     test_allow_header_get_or_head(sut)
     test_cache_control_header(sut)

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -482,7 +482,6 @@ class SystemUnderTest(object):
                             response.status_code)
         session.headers.update({'OData-Version': '4.0'})
         session.headers.update({'Accept-Encoding': 'identity'})
-        # TODO(bdodd): any other default headers to set?
         # session.headers.update({'Accept': 'application/json'})
         session.verify = self.verify
         self._set_session(session)

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -172,16 +172,6 @@ class Resources(TestCase):
             self.sut, func=resources.get_default_resources)
         self.assertEqual(self.session.get.call_count, 27)
 
-    def test_get_all_resources(self):
-        with self.assertRaises(NotImplementedError):
-            resources.read_target_resources(
-                self.sut, func=resources.get_all_resources)
-
-    def test_get_select_resources(self):
-        with self.assertRaises(NotImplementedError):
-            resources.read_target_resources(
-                self.sut, func=resources.get_select_resources)
-
     def test_set_mfr_model_fw(self):
         uuid1 = "92384634-2938-2342-8820-489239905423"
         uuid2 = '85775665-c110-4b85-8989-e6162170b3ec'

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -1219,11 +1219,11 @@ class SecurityDetails(TestCase):
         self.mock_session.get.return_value.headers = {'ETag': etag}
         self.mock_session.patch.return_value.ok = False
         self.mock_session.patch.return_value.status_code = (
-            requests.codes.BAD_REQUEST)
+            requests.codes.METHOD_NOT_ALLOWED)
         sec.test_priv_predefined_roles_not_modifiable(self.sut)
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + ro_uri,
-            json={'AssignedPrivileges': [{}, {}, test_priv]},
+            json={'AssignedPrivileges': test_priv},
             headers={'If-Match': etag})
         result = get_result(
             self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -1233,15 +1233,11 @@ class SecurityDetails(TestCase):
 
     def test_test_priv_predefined_roles_not_modifiable_fail1(self):
         ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
-        test_priv = ['Login', 'ConfigureManager', 'ConfigureUsers',
-                     'ConfigureComponents', 'ConfigureSelf']
         etag = 'abcd1234'
+        privs = ['Login', 'ConfigureSelf']
         payload = {
             'Id': 'ReadOnly',
-            'AssignedPrivileges': [
-                'Login',
-                'ConfigureSelf'
-            ]
+            'AssignedPrivileges': privs
         }
         add_response(self.sut, ro_uri, 'GET', requests.codes.OK,
                      res_type=ResourceType.ROLE, json=payload)
@@ -1253,7 +1249,7 @@ class SecurityDetails(TestCase):
         sec.test_priv_predefined_roles_not_modifiable(self.sut)
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + ro_uri,
-            json={'AssignedPrivileges': test_priv},
+            json={'AssignedPrivileges': privs},
             headers={'If-Match': etag})
         result = get_result(
             self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -1180,7 +1180,7 @@ class SecurityDetails(TestCase):
             'PATCH', '')
         self.assertIsNotNone(result)
         self.assertEqual(Result.NOT_TESTED, result['result'])
-        self.assertIn('Redefined role %s not found' % 'ReadOnly',
+        self.assertIn('Predefined role %s not found' % 'ReadOnly',
                       result['msg'])
 
     def test_test_priv_predefined_roles_not_modifiable_not_tested2(self):
@@ -1198,29 +1198,6 @@ class SecurityDetails(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.NOT_TESTED, result['result'])
         self.assertIn('No AssignedPrivileges found in role %s' % 'ReadOnly',
-                      result['msg'])
-
-    def test_test_priv_predefined_roles_not_modifiable_not_tested3(self):
-        ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
-        test_priv = 'RfProtoValTestPriv'
-        payload = {
-            'Id': 'ReadOnly',
-            'AssignedPrivileges': [
-                'Login',
-                'ConfigureSelf',
-                test_priv
-            ]
-        }
-        add_response(self.sut, ro_uri, 'GET', requests.codes.OK,
-                     res_type=ResourceType.ROLE, json=payload)
-        sec.test_priv_predefined_roles_not_modifiable(self.sut)
-        result = get_result(
-            self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
-            'PATCH', ro_uri)
-        self.assertIsNotNone(result)
-        self.assertEqual(Result.NOT_TESTED, result['result'])
-        self.assertIn('Test privilege %s already present in predefined role '
-                      '%s' % (test_priv, 'ReadOnly'),
                       result['msg'])
 
     def test_test_priv_predefined_roles_not_modifiable_pass(self):

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -1202,7 +1202,8 @@ class SecurityDetails(TestCase):
 
     def test_test_priv_predefined_roles_not_modifiable_pass(self):
         ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
-        test_priv = 'RfProtoValTestPriv'
+        test_priv = ['Login', 'ConfigureManager', 'ConfigureUsers',
+                     'ConfigureComponents', 'ConfigureSelf']
         etag = 'abcd1234'
         payload = {
             'Id': 'ReadOnly',
@@ -1232,7 +1233,8 @@ class SecurityDetails(TestCase):
 
     def test_test_priv_predefined_roles_not_modifiable_fail1(self):
         ro_uri = '/redfish/v1/AccountsService/Roles/ReadOnly'
-        test_priv = 'RfProtoValTestPriv'
+        test_priv = ['Login', 'ConfigureManager', 'ConfigureUsers',
+                     'ConfigureComponents', 'ConfigureSelf']
         etag = 'abcd1234'
         payload = {
             'Id': 'ReadOnly',
@@ -1251,7 +1253,7 @@ class SecurityDetails(TestCase):
         sec.test_priv_predefined_roles_not_modifiable(self.sut)
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + ro_uri,
-            json={'AssignedPrivileges': [{}, {}, test_priv]},
+            json={'AssignedPrivileges': test_priv},
             headers={'If-Match': etag})
         result = get_result(
             self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
@@ -1287,11 +1289,7 @@ class SecurityDetails(TestCase):
         mock_get2.headers = {'ETag': etag}
         mock_get2.json.return_value = {
             'Id': 'ReadOnly',
-            'AssignedPrivileges': [
-                'Login',
-                'ConfigureSelf',
-                test_priv
-            ]
+            'AssignedPrivileges': test_priv
         }
         self.mock_session.get.side_effect = [mock_get1, mock_get2]
         self.mock_session.patch.return_value.ok = True


### PR DESCRIPTION
Fix #60 

Unfortunately most of the TODOs are simply removing the comments/test stubs. Going over the list, many will be difficult to implement in a safe or predictable manner. If folks want specific tests, we can certainly file issues in the future in a more targeted manner.