### PR TITLE
HTTP hardening

### DIFF
--- a/redfish_protocol_validator/accounts.py
+++ b/redfish_protocol_validator/accounts.py
@@ -29,7 +29,7 @@ def get_user_names(sut: SystemUnderTest, session,
             if uri in responses:
                 response = responses[uri]
             else:
-                response = session.get(sut.rhost + uri)
+                response = sut.get(uri, session=session)
                 sut.add_response(uri, response,
                                  resource_type=ResourceType.MANAGER_ACCOUNT,
                                  request_type=request_type)
@@ -56,7 +56,7 @@ def get_available_roles(sut: SystemUnderTest, session,
             if uri in responses:
                 response = responses[uri]
             else:
-                response = session.get(sut.rhost + uri)
+                response = sut.get(uri, session=session)
                 sut.add_response(uri, response,
                                  resource_type=ResourceType.ROLE,
                                  request_type=request_type)
@@ -132,7 +132,7 @@ def find_empty_account_slot(sut: SystemUnderTest, session,
         if uri in responses:
             response = responses[uri]
         else:
-            response = session.get(sut.rhost + uri)
+            response = sut.get(uri, session=session)
             sut.add_response(uri, response,
                              resource_type=ResourceType.MANAGER_ACCOUNT,
                              request_type=request_type)
@@ -159,7 +159,7 @@ def add_account_via_patch(sut: SystemUnderTest, session, user, role, password,
                      request_type=request_type)
     success = response.status_code == requests.codes.OK
     if success:
-        response = session.get(sut.rhost + uri)
+        response = sut.get(uri, session=session)
         if response.ok:
             # Enable the account if it not already enabled
             data = utils.get_response_json(response)
@@ -209,7 +209,7 @@ def add_account(sut: SystemUnderTest, session,
             new_acct_uri = urlparse(location).path
         else:
             new_acct_uri = utils.get_response_json(response).get('@odata.id')
-        response = session.get(sut.rhost + new_acct_uri)
+        response = sut.get(new_acct_uri, session=session)
         sut.add_response(new_acct_uri, response,
                          resource_type=ResourceType.MANAGER_ACCOUNT,
                          request_type=request_type)
@@ -358,15 +358,13 @@ def password_change_required(sut: SystemUnderTest, session, user, password,
     sut.add_response(sut.sessions_uri, response,
                      request_type=RequestType.PWD_CHANGE_REQUIRED)
     # GET the account
-    response = requests.get(sut.rhost + uri, auth=(user, password),
-                            headers=headers, verify=sut.verify)
+    response = sut.get(uri, auth=(user, password), headers=headers, no_session=True)
     etag = utils.get_response_etag(response)
     sut.add_response(uri, response, resource_type=ResourceType.MANAGER_ACCOUNT,
                      request_type=RequestType.PWD_CHANGE_REQUIRED)
     # try to get protected resource
-    response = requests.get(sut.rhost + sut.sessions_uri,
-                            auth=(user, password), headers=headers, 
-                            verify=sut.verify)
+    response = sut.get(sut.sessions_uri, auth=(user, password), headers=headers, 
+                       no_session=True)
     sut.add_response(sut.sessions_uri, response,
                      request_type=RequestType.PWD_CHANGE_REQUIRED)
     # change password

--- a/redfish_protocol_validator/accounts.py
+++ b/redfish_protocol_validator/accounts.py
@@ -353,8 +353,8 @@ def password_change_required(sut: SystemUnderTest, session, user, password,
     headers = {
         'OData-Version': '4.0'
     }
-    response = requests.post(sut.rhost + sut.sessions_uri, json=payload,
-                             headers=headers, verify=sut.verify)
+    response = sut.post(sut.sessions_uri, json=payload,
+                        headers=headers, no_session=True)
     sut.add_response(sut.sessions_uri, response,
                      request_type=RequestType.PWD_CHANGE_REQUIRED)
     # GET the account
@@ -373,8 +373,8 @@ def password_change_required(sut: SystemUnderTest, session, user, password,
     payload = {'Password': new_password(sut)}
     if etag:
         headers['If-Match'] = etag
-    response = requests.patch(sut.rhost + uri, auth=(user, password), json=payload,
-                              headers=headers, verify=sut.verify)
+    response = sut.patch(uri, json=payload, headers=headers,
+                         no_session=True, auth=(user, password))
     sut.add_response(uri, response,
                      resource_type=ResourceType.MANAGER_ACCOUNT,
                      request_type=RequestType.PWD_CHANGE_REQUIRED)

--- a/redfish_protocol_validator/resources.py
+++ b/redfish_protocol_validator/resources.py
@@ -35,13 +35,13 @@ def set_mgr_net_proto_uri(sut: SystemUnderTest, data):
 def find_certificates(sut: SystemUnderTest, data):
     if 'NetworkProtocol' in data:
         uri = data['NetworkProtocol']['@odata.id']
-        r = sut.session.get(sut.rhost + uri)
+        r = sut.get(uri)
         yield {'uri': uri, 'response': r}
         if r.ok:
             d = utils.get_response_json(r)
             if 'HTTPS' in d and 'Certificates' in d['HTTPS']:
                 coll_uri = d['HTTPS']['Certificates']['@odata.id']
-                r = sut.session.get(sut.rhost + coll_uri)
+                r = sut.get(coll_uri)
                 yield {'uri': coll_uri, 'response': r}
                 if r.ok:
                     d = utils.get_response_json(r)
@@ -49,7 +49,7 @@ def find_certificates(sut: SystemUnderTest, data):
                         for m in d['Members']:
                             uri = m['@odata.id']
                             # uncomment next 2 lines if we need to read certs
-                            # r = session.get(sut.rhost + uri)
+                            # r = sut.get(uri)
                             # yield {'uri': uri, 'response': r}
                             sut.add_cert(coll_uri, uri)
 
@@ -65,25 +65,24 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
     :return: dict elements containing the URI and `requests` response
     """
     # do GETs on spec-defined URIs
-    yield {'uri': '/redfish', 'response': sut.session.get(
-        sut.rhost + '/redfish')}
+    yield {'uri': '/redfish', 'response': sut.get('/redfish')}
     yield {'uri': '/redfish/v1/odata', 'response':
-           sut.session.get(sut.rhost + '/redfish/v1/odata')}
+           sut.get('/redfish/v1/odata')}
     yield {'uri': '/redfish/v1', 'response':
-           sut.session.get(sut.rhost + '/redfish/v1')}
+           sut.get('/redfish/v1')}
     yield {'uri': '/redfish/v1/$metadata', 'response':
-           sut.session.get(sut.rhost + '/redfish/v1/$metadata',
-                           headers={'accept': 'application/xml'})}
+           sut.get('/redfish/v1/$metadata',
+                   headers={'accept': 'application/xml'})}
     yield {'uri': '/redfish/v1/openapi.yaml',
            'request_type': RequestType.YAML,
-           'response': sut.session.get(sut.rhost + '/redfish/v1/openapi.yaml',
-                                       headers={'accept': 'application/yaml'})}
+           'response': sut.get('/redfish/v1/openapi.yaml',
+                               headers={'accept': 'application/yaml'})}
 
     # do HEAD on the service root
-    r = sut.session.head(sut.rhost + uri)
+    r = sut.head(uri)
     yield {'uri': uri, 'response': r}
     # do GET on the service root
-    r = sut.session.get(sut.rhost + uri)
+    r = sut.get(uri)
     yield {'uri': uri, 'response': r}
     root = utils.get_response_json(r) if r.status_code == requests.codes.OK else {}
 
@@ -96,26 +95,26 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
         if prop in root:
             uri = root[prop]['@odata.id']
             sut.set_nav_prop_uri(prop, uri)
-            r = sut.session.get(sut.rhost + uri)
+            r = sut.get(uri)
             yield {'uri': uri, 'response': r}
             if r.ok:
                 data = utils.get_response_json(r)
                 if 'Members' in data and len(data['Members']):
                     uri = data['Members'][0]['@odata.id']
-                    r = sut.session.get(sut.rhost + uri)
+                    r = sut.get(uri)
                     yield {'uri': uri, 'response': r}
 
     if 'Managers' in root:
         uri = root['Managers']['@odata.id']
         sut.set_nav_prop_uri('Managers', uri)
-        r = sut.session.get(sut.rhost + uri)
+        r = sut.get(uri)
         yield {'uri': uri, 'response': r}
         if r.ok:
             data = utils.get_response_json(r)
             if 'Members' in data and len(data['Members']):
                 for m in data['Members']:
                     uri = m['@odata.id']
-                    r = sut.session.get(sut.rhost + uri)
+                    r = sut.get(uri)
                     yield {'uri': uri, 'response': r}
                     if r.ok:
                         d = utils.get_response_json(r)
@@ -127,7 +126,7 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
     if 'AccountService' in root:
         uri = root['AccountService']['@odata.id']
         sut.set_nav_prop_uri('AccountService', uri)
-        r = sut.session.get(sut.rhost + uri)
+        r = sut.get(uri)
         yield {'uri': uri, 'response': r}
         if r.ok:
             data = utils.get_response_json(r)
@@ -137,7 +136,7 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
             for prop in ['Accounts', 'Roles']:
                 if prop in data:
                     uri = data[prop]['@odata.id']
-                    r = sut.session.get(sut.rhost + uri)
+                    r = sut.get(uri)
                     yield {'uri': uri, 'response': r}
                     sut.set_nav_prop_uri(prop, uri)
                     if r.ok:
@@ -148,7 +147,7 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
                                 # get accounts up to sut.username
                                 for m in d['Members']:
                                     uri = m['@odata.id']
-                                    r = sut.session.get(sut.rhost + uri)
+                                    r = sut.get(uri)
                                     yield {'uri': uri, 'response': r,
                                            'resource_type': resource_type}
                                     if r.ok:
@@ -162,7 +161,7 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
                                 # get all the roles
                                 for m in d['Members']:
                                     uri = m['@odata.id']
-                                    r = sut.session.get(sut.rhost + uri)
+                                    r = sut.get(uri)
                                     yield {'uri': uri, 'response': r,
                                            'resource_type': resource_type}
                                     if r.ok:
@@ -170,25 +169,25 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
 
     if 'SessionService' in root:
         uri = root['SessionService']['@odata.id']
-        r = sut.session.get(sut.rhost + uri)
+        r = sut.get(uri)
         yield {'uri': uri, 'response': r}
         if r.ok:
             data = utils.get_response_json(r)
             if 'Sessions' in data:
                 uri = data['Sessions']['@odata.id']
-                r = sut.session.get(sut.rhost + uri)
+                r = sut.get(uri)
                 yield {'uri': uri, 'response': r}
                 if r.ok:
                     data = utils.get_response_json(r)
                     if 'Members' in data and len(data['Members']):
                         uri = data['Members'][0]['@odata.id']
-                        r = sut.session.get(sut.rhost + uri)
+                        r = sut.get(uri)
                         yield {'uri': uri, 'response': r}
 
     if 'EventService' in root:
         uri = root['EventService']['@odata.id']
         sut.set_nav_prop_uri('EventService', uri)
-        r = sut.session.get(sut.rhost + uri)
+        r = sut.get(uri)
         yield {'uri': uri, 'response': r}
         if r.ok:
             data = utils.get_response_json(r)
@@ -208,7 +207,7 @@ def get_default_resources(sut: SystemUnderTest, uri='/redfish/v1/',
     if 'CertificateService' in root:
         uri = root['CertificateService']['@odata.id']
         sut.set_nav_prop_uri('CertificateService', uri)
-        r = sut.session.get(sut.rhost + uri)
+        r = sut.get(uri)
         yield {'uri': uri, 'response': r}
 
 
@@ -286,7 +285,7 @@ def data_modification_requests(sut: SystemUnderTest):
         new_user, new_pwd, new_uri = create_account(
             sut, sut.session, request_type=RequestType.NORMAL)
         if new_uri:
-            response = sut.session.get(sut.rhost + new_uri)
+            response = sut.get(new_uri)
             sut.add_response(new_uri, response)
             if response.ok:
                 etag = utils.get_response_etag(response)
@@ -344,7 +343,7 @@ def unsupported_requests(sut: SystemUnderTest):
     response = sut.post(uri, json={})
     sut.add_response(uri, response, request_type=RequestType.UNSUPPORTED_REQ)
     # Unsupported HTTP methods return HTTP 501
-    response = sut.session.request('FAKEMETHODFORTEST', sut.rhost + uri)
+    response = sut.request('FAKEMETHODFORTEST', uri)
     sut.add_response(uri, response, request_type=RequestType.UNSUPPORTED_REQ)
 
 
@@ -354,9 +353,8 @@ def basic_auth_requests(sut: SystemUnderTest):
     }
     uri = sut.sessions_uri
     # good request
-    r = requests.get(sut.rhost + uri, headers=headers,
-                     auth=(sut.username, sut.password),
-                     verify=sut.verify)
+    r = sut.get(uri, headers=headers, auth=(sut.username, sut.password),
+                no_session=True)
     sut.add_response(uri, r, request_type=RequestType.BASIC_AUTH)
 
 
@@ -435,9 +433,8 @@ def bad_auth_requests(sut: SystemUnderTest):
     #       IP will be blocked for 600 seconds."
     uri = sut.sessions_uri
     h = headers.copy()
-    r = requests.get(sut.rhost + uri, headers=h,
-                     auth=(acct.new_username(set()), acct.new_password(sut)),
-                     verify=sut.verify)
+    r = sut.get(uri, headers=h, auth=(acct.new_username(set()), acct.new_password(sut)),
+                     no_session=True)
     sut.add_response(uri, r, request_type=RequestType.BAD_AUTH)
     # request with bad auth token
     token = 'rfpv%012x' % random.randrange(2 ** 48)  # ex: 'rfpv9e40b1f54c8a'
@@ -445,11 +442,11 @@ def bad_auth_requests(sut: SystemUnderTest):
     uri = '/redfish/v1/RPVfoobar'
     h = headers.copy()
     h.update({'X-Auth-Token': token})
-    r = requests.get(sut.rhost + uri, headers=h, verify=sut.verify)
+    r = sut.get(uri, headers=h, no_session=True)
     sut.add_response(uri, r, request_type=RequestType.BAD_AUTH)
 
 
 def read_uris_no_auth(sut: SystemUnderTest, session):
     for uri in sut.get_all_uris():
-        response = session.get(sut.rhost + uri)
+        response = sut.get(uri, session=session)
         sut.add_response(uri, response, request_type=RequestType.NO_AUTH)

--- a/redfish_protocol_validator/security_details.py
+++ b/redfish_protocol_validator/security_details.py
@@ -54,7 +54,7 @@ def test_tls_1_1(sut: SystemUnderTest):
     uri = '/redfish/v1/'
     status = ''
     try:
-        response = session.get(sut.rhost + uri)
+        response = sut.get(uri, session=session)
         status = response.status_code
         result = Result.PASS
         msg = 'Test passed'
@@ -316,8 +316,7 @@ def test_headers_auth_before_etag(sut: SystemUnderTest):
                 # make request w/ no auth and If-None-Match header
                 h = headers.copy()
                 h.update({'If-None-Match': etag})
-                r = requests.get(sut.rhost + uri, headers=h,
-                                 verify=sut.verify)
+                r = sut.get(uri, headers=h, no_session=True)
                 if r.status_code == requests.codes.UNAUTHORIZED:
                     sut.log(Result.PASS, 'GET', r.status_code, uri,
                             Assertion.SEC_HEADERS_FIRST, 'Test passed')
@@ -604,8 +603,7 @@ def test_session_termination_side_effects(sut: SystemUnderTest):
         response = None
         exc_name = ''
         try:
-            response = session.get(sut.rhost + sut.server_sent_event_uri,
-                                   stream=True)
+            response = sut.get(sut.server_sent_event_uri, session=session, stream=True)
         except Exception as e:
             exc_name = e.__class__.__name__
         if response is None:
@@ -939,7 +937,7 @@ def test_priv_predefined_roles_not_modifiable(sut: SystemUnderTest):
                         Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
                         msg)
                 # PATCH succeeded unexpectedly; try to PATCH it back
-                r = sut.session.get(sut.rhost + uri)
+                r = sut.get(uri)
                 if r.ok:
                     payload = {'AssignedPrivileges': privs}
                     etag = r.headers.get('ETag')

--- a/redfish_protocol_validator/security_details.py
+++ b/redfish_protocol_validator/security_details.py
@@ -450,15 +450,13 @@ def test_sessions_uri_location(sut: SystemUnderTest):
     response1 = sut.get_response('GET', '/redfish/v1/')
     if response1.ok:
         data = utils.get_response_json(response1)
-        if 'Links' in data and 'Sessions' in data['Links']:
-            sessions_uri1 = data['Links']['Sessions']['@odata.id']
-        if 'SessionService' in data:
-            uri = data['SessionService']['@odata.id']
+        sessions_uri1 = data.get('Links', {}).get('Sessions', {}).get('@odata.id')
+        uri = data.get('SessionService', {}).get('@odata.id')
+        if uri:
             response2 = sut.get_response('GET', uri)
             if response2.ok:
                 data = utils.get_response_json(response2)
-                if 'Sessions' in data:
-                    sessions_uri2 = data['Sessions']['@odata.id']
+                sessions_uri2 = data.get('Sessions', {}).get('@odata.id')
         if sessions_uri1 and sessions_uri2:
             if sessions_uri1 == sessions_uri2:
                 sut.log(Result.PASS, 'GET', response1.status_code,

--- a/redfish_protocol_validator/security_details.py
+++ b/redfish_protocol_validator/security_details.py
@@ -603,7 +603,8 @@ def test_session_termination_side_effects(sut: SystemUnderTest):
         response = None
         exc_name = ''
         try:
-            response = sut.get(sut.server_sent_event_uri, session=session, stream=True)
+            response = session.get(sut.rhost + sut.server_sent_event_uri,
+                                   stream=True)
         except Exception as e:
             exc_name = e.__class__.__name__
         if response is None:

--- a/redfish_protocol_validator/security_details.py
+++ b/redfish_protocol_validator/security_details.py
@@ -54,7 +54,7 @@ def test_tls_1_1(sut: SystemUnderTest):
     uri = '/redfish/v1/'
     status = ''
     try:
-        response = sut.get(uri, session=session)
+        response = session.get(sut.rhost + uri)
         status = response.status_code
         result = Result.PASS
         msg = 'Test passed'

--- a/redfish_protocol_validator/security_details.py
+++ b/redfish_protocol_validator/security_details.py
@@ -54,7 +54,7 @@ def test_tls_1_1(sut: SystemUnderTest):
     uri = '/redfish/v1/'
     status = ''
     try:
-        response = session.get(sut.rhost + uri)
+        response = sut.get(uri, session=session, allow_exception=True)
         status = response.status_code
         result = Result.PASS
         msg = 'Test passed'
@@ -603,8 +603,8 @@ def test_session_termination_side_effects(sut: SystemUnderTest):
         response = None
         exc_name = ''
         try:
-            response = session.get(sut.rhost + sut.server_sent_event_uri,
-                                   stream=True)
+            response = sut.get(sut.server_sent_event_uri, session=session,
+                               stream=True, allow_exception=True)
         except Exception as e:
             exc_name = e.__class__.__name__
         if response is None:

--- a/redfish_protocol_validator/service_details.py
+++ b/redfish_protocol_validator/service_details.py
@@ -495,9 +495,9 @@ def test_sse_unsuccessful_response(sut: SystemUnderTest):
     response = None
     exc_name = ''
     try:
-        response = sut.get(sut.server_sent_event_uri,
-                           headers={'Accept': 'application/json'},
-                           stream=True)
+        response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
+                                   headers={'Accept': 'application/json'},
+                                   stream=True)
     except Exception as e:
         exc_name = e.__class__.__name__
     if response is None:

--- a/redfish_protocol_validator/service_details.py
+++ b/redfish_protocol_validator/service_details.py
@@ -116,7 +116,7 @@ def pre_ssdp(sut: SystemUnderTest):
 
     # determine SSDP enabled/disabled state
     if sut.mgr_net_proto_uri:
-        r = sut.session.get(sut.rhost + sut.mgr_net_proto_uri)
+        r = sut.get(sut.mgr_net_proto_uri)
         if r.ok:
             sut.add_response(sut.mgr_net_proto_uri, r)
             d = utils.get_response_json(r)
@@ -495,9 +495,9 @@ def test_sse_unsuccessful_response(sut: SystemUnderTest):
     response = None
     exc_name = ''
     try:
-        response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
-                                   headers={'Accept': 'application/json'},
-                                   stream=True)
+        response = sut.get(sut.server_sent_event_uri,
+                           headers={'Accept': 'application/json'},
+                           stream=True)
     except Exception as e:
         exc_name = e.__class__.__name__
     if response is None:
@@ -653,7 +653,7 @@ def test_sse_event_dest_deleted_on_close(sut: SystemUnderTest, response):
     # wait for up to 60 seconds for EventDestination resource to be deleted
     status = requests.codes.OK
     for i in range(60):
-        r = sut.session.get(sut.rhost + sut.event_dest_uri)
+        r = sut.get(sut.event_dest_uri)
         if r.ok:
             # resource still present
             status = r.status_code
@@ -735,7 +735,7 @@ def test_sse_event_dest_context_opaque_str(sut: SystemUnderTest, event_dest):
                 Assertion.SERV_SSE_EVENT_DEST_CONTEXT_OPAQUE_STR, msg)
         return
 
-    r = sut.session.get(sut.rhost + event_dest)
+    r = sut.get(event_dest)
     if r.status_code == requests.codes.OK:
         data = utils.get_response_json(r)
         if 'Context' in data:

--- a/redfish_protocol_validator/service_details.py
+++ b/redfish_protocol_validator/service_details.py
@@ -495,9 +495,9 @@ def test_sse_unsuccessful_response(sut: SystemUnderTest):
     response = None
     exc_name = ''
     try:
-        response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
-                                   headers={'Accept': 'application/json'},
-                                   stream=True)
+        response = sut.get(sut.server_sent_event_uri,
+                           headers={'Accept': 'application/json'},
+                           stream=True, allow_exception=True)
     except Exception as e:
         exc_name = e.__class__.__name__
     if response is None:

--- a/redfish_protocol_validator/service_requests.py
+++ b/redfish_protocol_validator/service_requests.py
@@ -17,8 +17,7 @@ def test_header(sut: SystemUnderTest, header, header_values, uri, assertion,
                 stream=False):
     """Perform test for a particular header value"""
     for val in header_values:
-        response = sut.session.get(sut.rhost + uri, headers={header: val},
-                                   stream=stream)
+        response = sut.get(uri, headers={header: val}, stream=stream)
         if response.ok:
             msg = 'Test passed for header %s: %s' % (header, val)
             sut.log(Result.PASS, 'GET', response.status_code, uri,
@@ -197,8 +196,7 @@ def test_odata_version_header(sut: SystemUnderTest):
     uri = '/redfish/v1/'
 
     # supported OData-Version
-    response = sut.session.get(sut.rhost + uri,
-                               headers={'OData-Version': '4.0'})
+    response = sut.get(uri, headers={'OData-Version': '4.0'})
     if response.ok:
         msg = ('Test passed for supported header OData-Version: %s'
                % response.request.headers.get('OData-Version'))
@@ -211,8 +209,7 @@ def test_odata_version_header(sut: SystemUnderTest):
                 Assertion.REQ_HEADERS_ODATA_VERSION, msg)
 
     # unsupported OData-Version
-    response = sut.session.get(sut.rhost + uri,
-                               headers={'OData-Version': '4.1'})
+    response = sut.get(uri, headers={'OData-Version': '4.1'})
     if response.status_code == requests.codes.PRECONDITION_FAILED:
         msg = ('Test passed for unsupported header OData-Version: %s'
                % response.request.headers.get('OData-Version'))
@@ -281,7 +278,7 @@ def test_get_no_accept_header(sut: SystemUnderTest):
     """Perform tests for Assertion.REQ_GET_NO_ACCEPT_HEADER."""
     uri = '/redfish/v1/'
     headers = {'Accept': None}
-    response = sut.session.get(sut.rhost + uri, headers=headers)
+    response = sut.get(uri, headers=headers)
     if response.ok:
         if utils.get_response_media_type(response) == 'application/json':
             sut.log(Result.PASS, 'GET', response.status_code, uri,
@@ -304,7 +301,7 @@ def test_get_ignore_body(sut: SystemUnderTest):
     """Perform tests for Assertion.REQ_GET_IGNORE_BODY."""
     uri = '/redfish/v1/'
     payload = {}
-    response = sut.session.get(sut.rhost + uri, json=payload)
+    response = sut.get(uri, json=payload)
     if response.ok:
         sut.log(Result.PASS, 'GET', response.status_code, uri,
                 Assertion.REQ_GET_IGNORE_BODY, 'Test passed')
@@ -510,7 +507,7 @@ def test_get_metadata_odata_no_auth(sut: SystemUnderTest):
 def test_query_ignore_unsupported(sut: SystemUnderTest):
     """Perform tests for Assertion.REQ_QUERY_IGNORE_UNSUPPORTED."""
     uri = '/redfish/v1/?rpvunknown'
-    response = sut.session.get(sut.rhost + uri)
+    response = sut.get(uri)
     if response.ok:
         sut.log(Result.PASS, 'GET', response.status_code, uri,
                 Assertion.REQ_QUERY_IGNORE_UNSUPPORTED, 'Test passed')
@@ -555,7 +552,7 @@ def test_query_unsupported_dollar_params_ext_error(
 def test_query_unsupported_dollar_params(sut: SystemUnderTest):
     """Perform tests for Assertion.REQ_QUERY_UNSUPPORTED_DOLLAR_PARAMS."""
     uri = '/redfish/v1/?$rpvunknown'
-    response = sut.session.get(sut.rhost + uri)
+    response = sut.get(uri)
     if response.status_code == requests.codes.NOT_IMPLEMENTED:
         sut.log(Result.PASS, 'GET', response.status_code, uri,
                 Assertion.REQ_QUERY_UNSUPPORTED_DOLLAR_PARAMS, 'Test passed')
@@ -588,7 +585,7 @@ def test_query_invalid_values(sut: SystemUnderTest):
         return
 
     for uri in uris:
-        response = sut.session.get(sut.rhost + uri)
+        response = sut.get(uri)
         if response.status_code == requests.codes.BAD_REQUEST:
             sut.log(Result.PASS, 'GET', response.status_code, uri,
                     Assertion.REQ_QUERY_INVALID_VALUES,
@@ -830,7 +827,7 @@ def test_patch_array_element_remove(sut: SystemUnderTest):
         headers = utils.get_etag_header(sut, sut.session, uri)
         response = sut.patch(uri, json=payload2, headers=headers)
         if response.ok:
-            get_resp = sut.session.get(sut.rhost + uri)
+            get_resp = sut.get(uri)
             try:
                 if get_resp.ok:
                     array = utils.get_response_json(get_resp).get('NTP', {}).get('NTPServers', None)
@@ -897,7 +894,7 @@ def test_patch_array_element_unchanged(sut: SystemUnderTest):
         headers = utils.get_etag_header(sut, sut.session, uri)
         response = sut.patch(uri, json=payload2, headers=headers)
         if response.ok:
-            get_resp = sut.session.get(sut.rhost + uri)
+            get_resp = sut.get(uri)
             try:
                 if get_resp.ok:
                     array = utils.get_response_json(get_resp).get('NTP', {}).get('NTPServers', None)
@@ -972,7 +969,7 @@ def test_patch_array_truncate(sut: SystemUnderTest):
         headers = utils.get_etag_header(sut, sut.session, uri)
         response = sut.patch(uri, json=payload2, headers=headers)
         if response.ok:
-            get_resp = sut.session.get(sut.rhost + uri)
+            get_resp = sut.get(uri)
             try:
                 if get_resp.ok:
                     array = utils.get_response_json(get_resp).get('NTP', {}).get('NTPServers', None)

--- a/redfish_protocol_validator/service_requests.py
+++ b/redfish_protocol_validator/service_requests.py
@@ -1090,8 +1090,7 @@ def test_post_create_to_members_prop(sut: SystemUnderTest):
         'OData-Version': '4.0',
         'Content-Type': 'application/json;charset=utf-8'
     }
-    response = requests.post(sut.rhost + uri, json=payload, headers=headers,
-                             verify=sut.verify)
+    response = sut.post(uri, json=payload, headers=headers, no_session=True)
     if response.ok:
         sut.log(Result.PASS, 'POST', response.status_code, uri,
                 Assertion.REQ_POST_CREATE_TO_MEMBERS_PROP,
@@ -1122,15 +1121,13 @@ def test_post_create_not_idempotent(sut: SystemUnderTest):
         'OData-Version': '4.0',
         'Content-Type': 'application/json;charset=utf-8'
     }
-    r1 = requests.post(sut.rhost + uri, json=payload, headers=headers,
-                       verify=sut.verify)
+    r1 = sut.post(uri, json=payload, headers=headers, no_session=True)
     if r1.ok:
         loc1 = r1.headers.get('Location')
         session_uri1 = ''
         if loc1 and isinstance(loc1, str):
             session_uri1 = urlparse(loc1).path
-        r2 = requests.post(sut.rhost + uri, json=payload, headers=headers,
-                           verify=sut.verify)
+        r2 = sut.post(uri, json=payload, headers=headers, no_session=True)
         if r2.ok:
             loc2 = r2.headers.get('Location')
             session_uri2 = ''

--- a/redfish_protocol_validator/service_requests.py
+++ b/redfish_protocol_validator/service_requests.py
@@ -17,7 +17,12 @@ def test_header(sut: SystemUnderTest, header, header_values, uri, assertion,
                 stream=False):
     """Perform test for a particular header value"""
     for val in header_values:
-        response = sut.get(uri, headers={header: val}, stream=stream)
+        # TODO: Need to remove this check
+        if stream:
+            response = sut.session.get(sut.rhost + uri, headers={header: val},
+                                       stream=stream)
+        else:
+            response = sut.get(uri, headers={header: val})
         if response.ok:
             msg = 'Test passed for header %s: %s' % (header, val)
             sut.log(Result.PASS, 'GET', response.status_code, uri,

--- a/redfish_protocol_validator/service_requests.py
+++ b/redfish_protocol_validator/service_requests.py
@@ -14,15 +14,11 @@ from redfish_protocol_validator.system_under_test import SystemUnderTest
 
 
 def test_header(sut: SystemUnderTest, header, header_values, uri, assertion,
-                stream=False):
+                stream=False, allow_exception=False):
     """Perform test for a particular header value"""
     for val in header_values:
-        # TODO: Need to remove this check
-        if stream:
-            response = sut.session.get(sut.rhost + uri, headers={header: val},
-                                       stream=stream)
-        else:
-            response = sut.get(uri, headers={header: val})
+        response = sut.get(uri, headers={header: val}, stream=stream,
+                           allow_exception=allow_exception)
         if response.ok:
             msg = 'Test passed for header %s: %s' % (header, val)
             sut.log(Result.PASS, 'GET', response.status_code, uri,
@@ -76,7 +72,7 @@ def test_accept_header(sut: SystemUnderTest):
     if uri:
         try:
             test_header(sut, header, header_values, uri, assertion,
-                        stream=True)
+                        stream=True, allow_exception=True)
         except Exception as e:
             msg = ('Caught %s while opening SSE stream with valid '
                    '"text/event-stream" Accept headers' % e.__class__.__name__)

--- a/redfish_protocol_validator/sessions.py
+++ b/redfish_protocol_validator/sessions.py
@@ -26,8 +26,8 @@ def bad_login(sut: SystemUnderTest):
     headers = {
         'OData-Version': '4.0'
     }
-    response = requests.post(sut.rhost + sut.sessions_uri, json=payload,
-                             headers=headers, verify=sut.verify)
+    response = sut.post(sut.sessions_uri, json=payload,
+                        headers=headers, no_session=True)
     sut.add_response(sut.sessions_uri, response,
                      request_type=RequestType.BAD_AUTH)
 
@@ -41,8 +41,8 @@ def create_session(sut: SystemUnderTest):
         'OData-Version': '4.0',
         'Content-Type': 'application/json;charset=utf-8'
     }
-    response = requests.post(sut.rhost + sut.sessions_uri, json=payload,
-                             headers=headers, verify=sut.verify)
+    response = sut.post(sut.sessions_uri, json=payload,
+                        headers=headers, no_session=True)
     if not response.ok:
         logging.warning('session POST status: %s, response: %s' % (
             response.status_code, response.text))

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -457,7 +457,7 @@ class SystemUnderTest(object):
         if session is None:
             session = self._session
         if no_session or session is None:
-            response = requests.post(self.rhost + uri, json=json, headers=headers, verify=sut.verify)
+            response = requests.post(self.rhost + uri, json=json, headers=headers, verify=self.verify)
         else:
             response = session.post(self.rhost + uri, json=json, headers=headers)
         return poll_task(self, response, session)
@@ -498,7 +498,7 @@ class SystemUnderTest(object):
         if session is None:
             session = self._session
         if no_session or session is None:
-            response = requests.delete(self.rhost + uri, headers=headers, verify=sut.verify)
+            response = requests.delete(self.rhost + uri, headers=headers, verify=self.verify)
         else:
             response = session.delete(self.rhost + uri, headers=headers)
         return poll_task(self, response, session)

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -500,7 +500,7 @@ class SystemUnderTest(object):
         except Exception as e:
             if allow_exception:
                 raise
-            response = build_exception_response(e, uri, method)
+            response = build_exception_response(e, uri, "HEAD")
         return response
 
     def get(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
@@ -530,7 +530,7 @@ class SystemUnderTest(object):
         except Exception as e:
             if allow_exception:
                 raise
-            response = build_exception_response(e, uri, method)
+            response = build_exception_response(e, uri, "GET")
         return response
 
     def post(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, allow_exception=False):
@@ -559,7 +559,7 @@ class SystemUnderTest(object):
         except Exception as e:
             if allow_exception:
                 raise
-            response = build_exception_response(e, uri, method)
+            response = build_exception_response(e, uri, "POST")
         return poll_task(self, response, session)
 
     def patch(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, allow_exception=False):
@@ -588,7 +588,7 @@ class SystemUnderTest(object):
         except Exception as e:
             if allow_exception:
                 raise
-            response = build_exception_response(e, uri, method)
+            response = build_exception_response(e, uri, "PATCH")
         return poll_task(self, response, session)
 
     def delete(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, allow_exception=False):
@@ -617,7 +617,7 @@ class SystemUnderTest(object):
         except Exception as e:
             if allow_exception:
                 raise
-            response = build_exception_response(e, uri, method)
+            response = build_exception_response(e, uri, "DELETE")
         return poll_task(self, response, session)
 
     def login(self):

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -428,17 +428,19 @@ class SystemUnderTest(object):
         r = self.get('/redfish/v1/', headers=headers, no_session=True)
         if r.status_code == requests.codes.OK:
             data = get_response_json(r)
-            if 'Links' in data and 'Sessions' in data['Links']:
-                return data['Links']['Sessions']['@odata.id']
-            elif 'SessionService' in data:
-                uri = data['SessionService']['@odata.id']
+            uri = data.get('Links', {}).get('Sessions', {}).get('@odata.id')
+            if uri:
+                return uri
+            uri = data.get('SessionService', {}).get('@odata.id')
+            if uri:
                 r = self.get(uri, headers=headers,
                              auth=(self.username, self.password),
                              no_session=True)
                 if r.status_code == requests.codes.OK:
                     data = get_response_json(r)
-                    if 'Sessions' in data:
-                        return data['Sessions']['@odata.id']
+                    uri = data.get('Sessions', {}).get('@odata.id')
+                    if uri:
+                        return uri
         return '/redfish/v1/SessionService/Sessions'
 
     def request(self, method, uri, session=None, no_session=False):

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -458,9 +458,9 @@ class SystemUnderTest(object):
             if session is None:
                 session = self._session
             if no_session or session is None:
-                response = requests.request(method, self.rhost + uri, verify=self.verify)
+                response = requests.request(method, self.rhost + uri, verify=self.verify, timeout=30)
             else:
-                response = session.request(method, self.rhost + uri)
+                response = session.request(method, self.rhost + uri, timeout=30)
         except Exception as e:
             response = build_exception_response(e, uri, method)
         return response
@@ -479,9 +479,9 @@ class SystemUnderTest(object):
             if session is None:
                 session = self._session
             if no_session or session is None:
-                response = requests.head(self.rhost + uri, verify=self.verify)
+                response = requests.head(self.rhost + uri, verify=self.verify, timeout=30)
             else:
-                response = session.head(self.rhost + uri)
+                response = session.head(self.rhost + uri, timeout=30)
         except Exception as e:
             response = build_exception_response(e, uri, "HEAD")
         return response
@@ -506,10 +506,10 @@ class SystemUnderTest(object):
                 session = self._session
             if no_session or session is None:
                 response = requests.get(self.rhost + uri, json=json, headers=headers,
-                                        auth=auth, stream=stream, verify=self.verify)
+                                        auth=auth, stream=stream, verify=self.verify, timeout=30)
             else:
                 response = session.get(self.rhost + uri, json=json, headers=headers,
-                                       auth=auth, stream=stream)
+                                       auth=auth, stream=stream, timeout=30)
         except Exception as e:
             if allow_exception:
                 # Caller is expecting to handle exceptions
@@ -533,9 +533,9 @@ class SystemUnderTest(object):
             if session is None:
                 session = self._session
             if no_session or session is None:
-                response = requests.post(self.rhost + uri, json=json, headers=headers, verify=self.verify)
+                response = requests.post(self.rhost + uri, json=json, headers=headers, verify=self.verify, timeout=30)
             else:
-                response = session.post(self.rhost + uri, json=json, headers=headers)
+                response = session.post(self.rhost + uri, json=json, headers=headers, timeout=30)
         except Exception as e:
             response = build_exception_response(e, uri, "POST")
         return poll_task(self, response, session)
@@ -558,9 +558,9 @@ class SystemUnderTest(object):
                 session = self._session
             if no_session or session is None:
                 response = requests.patch(self.rhost + uri, json=json, headers=headers,
-                                          verify=self.verify, auth=auth)
+                                          verify=self.verify, auth=auth, timeout=30)
             else:
-                response = session.patch(self.rhost + uri, json=json, headers=headers)
+                response = session.patch(self.rhost + uri, json=json, headers=headers, timeout=30)
         except Exception as e:
             response = build_exception_response(e, uri, "PATCH")
         return poll_task(self, response, session)
@@ -580,9 +580,9 @@ class SystemUnderTest(object):
             if session is None:
                 session = self._session
             if no_session or session is None:
-                response = requests.delete(self.rhost + uri, headers=headers, verify=self.verify)
+                response = requests.delete(self.rhost + uri, headers=headers, verify=self.verify, timeout=30)
             else:
-                response = session.delete(self.rhost + uri, headers=headers)
+                response = session.delete(self.rhost + uri, headers=headers, timeout=30)
         except Exception as e:
             response = build_exception_response(e, uri, "DELETE")
         return poll_task(self, response, session)

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -566,7 +566,6 @@ class SystemUnderTest(object):
             response = requests.Response()
             response.status_code = 600
             response.reason = "Exception"
-            response.ok = False
             response.url = uri
         return poll_task(self, response, session)
 

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -567,7 +567,7 @@ class SystemUnderTest(object):
             response.status_code = 600
             response.reason = "Exception"
             response.url = uri
-            response.request = request.Request()
+            response.request = requests.Request()
             response.request.method = "DELETE"
         return poll_task(self, response, session)
 

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -567,6 +567,8 @@ class SystemUnderTest(object):
             response.status_code = 600
             response.reason = "Exception"
             response.url = uri
+            response.request = request.Request()
+            response.request.method = "DELETE"
         return poll_task(self, response, session)
 
     def login(self):

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -458,7 +458,7 @@ class SystemUnderTest(object):
             session = self._session
         if no_session or session is None:
             response = requests.post(self.rhost + uri, json=json, headers=headers, verify=sut.verify)
-        else session:
+        else:
             response = session.post(self.rhost + uri, json=json, headers=headers)
         return poll_task(self, response, session)
 

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -452,12 +452,20 @@ class SystemUnderTest(object):
 
         :return: A response object for the HEAD operation
         """
-        if session is None:
-            session = self._session
-        if no_session or session is None:
-            response = requests.request(method, self.rhost + uri, verify=self.verify)
-        else:
-            response = session.request(method, self.rhost + uri)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.request(method, self.rhost + uri, verify=self.verify)
+            else:
+                response = session.request(method, self.rhost + uri)
+        except Exception as e:
+            response = requests.Response()
+            response.status_code = 600
+            response.reason = "Exception"
+            response.url = uri
+            response.request = requests.Request()
+            response.request.method = method
         return response
 
     def head(self, uri, session=None, no_session=False):
@@ -470,12 +478,20 @@ class SystemUnderTest(object):
 
         :return: A response object for the HEAD operation
         """
-        if session is None:
-            session = self._session
-        if no_session or session is None:
-            response = requests.head(self.rhost + uri, verify=self.verify)
-        else:
-            response = session.head(self.rhost + uri)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.head(self.rhost + uri, verify=self.verify)
+            else:
+                response = session.head(self.rhost + uri)
+        except Exception as e:
+            response = requests.Response()
+            response.status_code = 600
+            response.reason = "Exception"
+            response.url = uri
+            response.request = requests.Request()
+            response.request.method = "HEAD"
         return response
 
     def get(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False):
@@ -492,14 +508,22 @@ class SystemUnderTest(object):
 
         :return: A response object for the GET operation
         """
-        if session is None:
-            session = self._session
-        if no_session or session is None:
-            response = requests.get(self.rhost + uri, json=json, headers=headers,
-                                    auth=auth, stream=stream, verify=self.verify)
-        else:
-            response = session.get(self.rhost + uri, json=json, headers=headers,
-                                   auth=auth, stream=stream)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.get(self.rhost + uri, json=json, headers=headers,
+                                        auth=auth, stream=stream, verify=self.verify)
+            else:
+                response = session.get(self.rhost + uri, json=json, headers=headers,
+                                       auth=auth, stream=stream)
+        except Exception as e:
+            response = requests.Response()
+            response.status_code = 600
+            response.reason = "Exception"
+            response.url = uri
+            response.request = requests.Request()
+            response.request.method = "GET"
         return response
 
     def post(self, uri, json=None, headers=None, session=None, no_session=False):
@@ -514,12 +538,20 @@ class SystemUnderTest(object):
 
         :return: A response object for the POST operation
         """
-        if session is None:
-            session = self._session
-        if no_session or session is None:
-            response = requests.post(self.rhost + uri, json=json, headers=headers, verify=self.verify)
-        else:
-            response = session.post(self.rhost + uri, json=json, headers=headers)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.post(self.rhost + uri, json=json, headers=headers, verify=self.verify)
+            else:
+                response = session.post(self.rhost + uri, json=json, headers=headers)
+        except Exception as e:
+            response = requests.Response()
+            response.status_code = 600
+            response.reason = "Exception"
+            response.url = uri
+            response.request = requests.Request()
+            response.request.method = "POST"
         return poll_task(self, response, session)
 
     def patch(self, uri, json=None, headers=None, session=None, no_session=False, auth=None):
@@ -535,13 +567,21 @@ class SystemUnderTest(object):
 
         :return: A response object for the PATCH operation
         """
-        if session is None:
-            session = self._session
-        if no_session or session is None:
-            response = requests.patch(self.rhost + uri, json=json, headers=headers,
-                                      verify=self.verify, auth=auth)
-        else:
-            response = session.patch(self.rhost + uri, json=json, headers=headers)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.patch(self.rhost + uri, json=json, headers=headers,
+                                          verify=self.verify, auth=auth)
+            else:
+                response = session.patch(self.rhost + uri, json=json, headers=headers)
+        except Exception as e:
+            response = requests.Response()
+            response.status_code = 600
+            response.reason = "Exception"
+            response.url = uri
+            response.request = requests.Request()
+            response.request.method = "PATCH"
         return poll_task(self, response, session)
 
     def delete(self, uri, headers=None, session=None, no_session=False):

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -632,8 +632,7 @@ class SystemUnderTest(object):
 
     def logout(self):
         if self.active_session_uri:
-            response = self.session.delete(
-                self.rhost + self.active_session_uri)
+            response = self.delete(self.active_session_uri)
             if response.ok:
                 self._set_session(None)
                 self._set_active_session_uri(None)

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -474,17 +474,23 @@ class SystemUnderTest(object):
             response = build_exception_response(e, uri, method)
         return response
 
-    def head(self, uri, session=None, no_session=False):
+    def head(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
         """
         Performs a HEAD request
 
         :param uri: The URI of the HEAD request
+        :param json: The JSON payload to send with the HEAD request
+        :param headers: HTTP headers to include in the HEAD request
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
+        :param auth: Authentication header info; only supported when not using an existing session
+        :param stream: Indicates if the request will open a stream
+        :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the HEAD operation
         """
-        return self.request("HEAD", uri, session=session, no_session=no_session)
+        return self.request("HEAD", uri, json=json, headers=headers, session=session,
+                            no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
 
     def get(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
         """
@@ -504,7 +510,7 @@ class SystemUnderTest(object):
         return self.request("GET", uri, json=json, headers=headers, session=session,
                             no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
 
-    def post(self, uri, json=None, headers=None, session=None, no_session=False):
+    def post(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
         """
         Performs a POST request with task polling
 
@@ -513,13 +519,17 @@ class SystemUnderTest(object):
         :param headers: HTTP headers to include in the POST request
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
+        :param auth: Authentication header info; only supported when not using an existing session
+        :param stream: Indicates if the request will open a stream
+        :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the POST operation
         """
-        response = self.request("POST", uri, json=json, headers=headers, session=session, no_session=no_session)
+        response = self.request("POST", uri, json=json, headers=headers, session=session,
+                                no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
         return poll_task(self, response, session)
 
-    def patch(self, uri, json=None, headers=None, session=None, no_session=False, auth=None):
+    def patch(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
         """
         Performs a PATCH request with task polling
 
@@ -529,25 +539,32 @@ class SystemUnderTest(object):
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
         :param auth: Authentication header info; only supported when not using an existing session
+        :param stream: Indicates if the request will open a stream
+        :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the PATCH operation
         """
         response = self.request("PATCH", uri, json=json, headers=headers, session=session,
-                                no_session=no_session, auth=auth)
+                                no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
         return poll_task(self, response, session)
 
-    def delete(self, uri, headers=None, session=None, no_session=False):
+    def delete(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
         """
         Performs a DELETE request with task polling
 
-        :param uri: The URI of the POST request
+        :param uri: The URI of the DELETE request
+        :param json: The JSON payload to send with the DELETE request
         :param headers: HTTP headers to include in the DELETE request
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
+        :param auth: Authentication header info; only supported when not using an existing session
+        :param stream: Indicates if the request will open a stream
+        :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the DELETE operation
         """
-        response = self.request("DELETE", uri, headers=headers, session=session, no_session=no_session)
+        response = self.request("DELETE", uri, json=json, headers=headers, session=session,
+                                no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
         return poll_task(self, response, session)
 
     def login(self):

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -555,12 +555,19 @@ class SystemUnderTest(object):
 
         :return: A response object for the DELETE operation
         """
-        if session is None:
-            session = self._session
-        if no_session or session is None:
-            response = requests.delete(self.rhost + uri, headers=headers, verify=self.verify)
-        else:
-            response = session.delete(self.rhost + uri, headers=headers)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.delete(self.rhost + uri, headers=headers, verify=self.verify)
+            else:
+                response = session.delete(self.rhost + uri, headers=headers)
+        except Exception as e:
+            response = requests.Response()
+            response.status_code = 600
+            response.reason = "Exception"
+            response.ok = False
+            response.url = uri
         return poll_task(self, response, session)
 
     def login(self):

--- a/redfish_protocol_validator/system_under_test.py
+++ b/redfish_protocol_validator/system_under_test.py
@@ -474,7 +474,7 @@ class SystemUnderTest(object):
             response = build_exception_response(e, uri, method)
         return response
 
-    def head(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
+    def head(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, allow_exception=False):
         """
         Performs a HEAD request
 
@@ -484,13 +484,24 @@ class SystemUnderTest(object):
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
         :param auth: Authentication header info; only supported when not using an existing session
-        :param stream: Indicates if the request will open a stream
         :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the HEAD operation
         """
-        return self.request("HEAD", uri, json=json, headers=headers, session=session,
-                            no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.head(self.rhost + uri, json=json, headers=headers,
+                                         auth=auth, verify=self.verify, timeout=30)
+            else:
+                response = session.head(self.rhost + uri, json=json, headers=headers,
+                                        auth=auth, timeout=30)
+        except Exception as e:
+            if allow_exception:
+                raise
+            response = build_exception_response(e, uri, method)
+        return response
 
     def get(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
         """
@@ -507,10 +518,22 @@ class SystemUnderTest(object):
 
         :return: A response object for the GET operation
         """
-        return self.request("GET", uri, json=json, headers=headers, session=session,
-                            no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.get(self.rhost + uri, json=json, headers=headers,
+                                        auth=auth, stream=stream, verify=self.verify, timeout=30)
+            else:
+                response = session.get(self.rhost + uri, json=json, headers=headers,
+                                       auth=auth, stream=stream, timeout=30)
+        except Exception as e:
+            if allow_exception:
+                raise
+            response = build_exception_response(e, uri, method)
+        return response
 
-    def post(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
+    def post(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, allow_exception=False):
         """
         Performs a POST request with task polling
 
@@ -520,16 +543,26 @@ class SystemUnderTest(object):
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
         :param auth: Authentication header info; only supported when not using an existing session
-        :param stream: Indicates if the request will open a stream
         :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the POST operation
         """
-        response = self.request("POST", uri, json=json, headers=headers, session=session,
-                                no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.post(self.rhost + uri, json=json, headers=headers,
+                                         auth=auth, verify=self.verify, timeout=30)
+            else:
+                response = session.post(self.rhost + uri, json=json, headers=headers,
+                                        auth=auth, timeout=30)
+        except Exception as e:
+            if allow_exception:
+                raise
+            response = build_exception_response(e, uri, method)
         return poll_task(self, response, session)
 
-    def patch(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
+    def patch(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, allow_exception=False):
         """
         Performs a PATCH request with task polling
 
@@ -539,16 +572,26 @@ class SystemUnderTest(object):
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
         :param auth: Authentication header info; only supported when not using an existing session
-        :param stream: Indicates if the request will open a stream
         :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the PATCH operation
         """
-        response = self.request("PATCH", uri, json=json, headers=headers, session=session,
-                                no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.patch(self.rhost + uri, json=json, headers=headers,
+                                          auth=auth, verify=self.verify, timeout=30)
+            else:
+                response = session.patch(self.rhost + uri, json=json, headers=headers,
+                                         auth=auth, timeout=30)
+        except Exception as e:
+            if allow_exception:
+                raise
+            response = build_exception_response(e, uri, method)
         return poll_task(self, response, session)
 
-    def delete(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, stream=False, allow_exception=False):
+    def delete(self, uri, json=None, headers=None, session=None, no_session=False, auth=None, allow_exception=False):
         """
         Performs a DELETE request with task polling
 
@@ -558,13 +601,23 @@ class SystemUnderTest(object):
         :param session: Session object if using a session other than the sut's
         :param no_session: Indicates if session usage should be skipped
         :param auth: Authentication header info; only supported when not using an existing session
-        :param stream: Indicates if the request will open a stream
         :param allow_exception: Indicates if exceptions are allowed
 
         :return: A response object for the DELETE operation
         """
-        response = self.request("DELETE", uri, json=json, headers=headers, session=session,
-                                no_session=no_session, auth=auth, stream=stream, allow_exception=allow_exception)
+        try:
+            if session is None:
+                session = self._session
+            if no_session or session is None:
+                response = requests.delete(self.rhost + uri, json=json, headers=headers,
+                                           auth=auth, verify=self.verify, timeout=30)
+            else:
+                response = session.delete(self.rhost + uri, json=json, headers=headers,
+                                          auth=auth, timeout=30)
+        except Exception as e:
+            if allow_exception:
+                raise
+            response = build_exception_response(e, uri, method)
         return poll_task(self, response, session)
 
     def login(self):

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -100,6 +100,8 @@ def build_exception_response(exception, uri, method):
     response.url = uri
     response.request = requests.Request()
     response.request.method = method
+    logging.error('%s on %s caused %s exception; building HTTP 600 '
+                  'response' % (method, uri, type(exception).__name__))
     return response
 
 

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -161,17 +161,18 @@ def get_sse_stream(sut):
     try:
         # get the "before" set of EventDestination URIs
         if sut.subscriptions_uri:
-            r = sut.get(sut.subscriptions_uri)
+            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
             if r.status_code == requests.codes.OK:
                 data = get_response_json(r)
                 subs = set([m.get('@odata.id') for m in data.get('Members', [])
                             if '@odata.id' in m])
 
         if sut.server_sent_event_uri:
-            response = sut.get(sut.server_sent_event_uri, stream=True)
+            response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
+                                       stream=True)
         if response is not None and response.ok and sut.subscriptions_uri:
             # get the "after" set of EventDestination URIs
-            r = sut.get(sut.subscriptions_uri)
+            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
             if r.status_code == requests.codes.OK:
                 data = get_response_json(r)
                 new_subs = set([m.get('@odata.id') for m in

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -100,6 +100,7 @@ def build_exception_response(exception, uri, method):
     response.url = uri
     response.request = requests.Request()
     response.request.method = method
+    response.request.body = None
     logging.error('%s on %s caused %s exception; building HTTP 600 '
                   'response' % (method, uri, type(exception).__name__))
     return response

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -93,6 +93,16 @@ def get_response_json(response: requests.Response):
     return data
 
 
+def build_exception_response(exception, uri, method):
+    response = requests.Response()
+    response.status_code = 600
+    response.reason = "Exception"
+    response.url = uri
+    response.request = requests.Request()
+    response.request.method = method
+    return response
+
+
 def get_extended_info_message_keys(body: dict):
     data = []
     if 'error' in body and '@Message.ExtendedInfo' in body['error']:
@@ -161,18 +171,18 @@ def get_sse_stream(sut):
     try:
         # get the "before" set of EventDestination URIs
         if sut.subscriptions_uri:
-            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
+            r = sut.get(sut.subscriptions_uri, allow_exception=True)
             if r.status_code == requests.codes.OK:
                 data = get_response_json(r)
                 subs = set([m.get('@odata.id') for m in data.get('Members', [])
                             if '@odata.id' in m])
 
         if sut.server_sent_event_uri:
-            response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
-                                       stream=True)
+            response = sut.get(sut.server_sent_event_uri,
+                               stream=True, allow_exception=True)
         if response is not None and response.ok and sut.subscriptions_uri:
             # get the "after" set of EventDestination URIs
-            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
+            r = sut.get(sut.subscriptions_uri, allow_exception=True)
             if r.status_code == requests.codes.OK:
                 data = get_response_json(r)
                 new_subs = set([m.get('@odata.id') for m in

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -132,6 +132,14 @@ def poll_task(sut, response, session=None):
     # If the response doesn't show 202 Accepted, there's nothing to poll
     if response.status_code != requests.codes.ACCEPTED:
         return response
+    if session is None:
+        session = sut.session
+    if session is None:
+        # If no session is set up, don't poll
+        # May want to revisit this later; there are only a few tests that do
+        # not use the requests sessions, and they are not expected to produce
+        # tasks
+        return response
 
     # Get the task monitor URI and poll it
     task_monitor = response.headers.get('Location')
@@ -139,10 +147,7 @@ def poll_task(sut, response, session=None):
         # Try for up to 1 minute at 5 second intervals
         for _ in range(12):
             time.sleep(5)
-            if session:
-                response = session.get(sut.rhost + task_monitor)
-            else:
-                response = sut.session.get(sut.rhost + task_monitor)
+            response = session.get(sut.rhost + task_monitor)
             # Once the task is done, break out
             if response.status_code != requests.codes.ACCEPTED:
                 break

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -101,6 +101,7 @@ def build_exception_response(exception, uri, method):
     response.request = requests.Request()
     response.request.method = method
     response.request.body = None
+    response.request.path_url = uri
     logging.error('%s on %s caused %s exception; building HTTP 600 '
                   'response' % (method, uri, type(exception).__name__))
     return response

--- a/redfish_protocol_validator/utils.py
+++ b/redfish_protocol_validator/utils.py
@@ -38,7 +38,7 @@ def get_response_media_type_charset(response):
 
 
 def get_etag_header(sut, session, uri):
-    response = session.get(sut.rhost + uri)
+    response = sut.get(uri, session=session)
     etag = None
     if response.ok:
         etag = response.headers.get('ETag')
@@ -147,7 +147,7 @@ def poll_task(sut, response, session=None):
         # Try for up to 1 minute at 5 second intervals
         for _ in range(12):
             time.sleep(5)
-            response = session.get(sut.rhost + task_monitor)
+            response = sut.get(task_monitor, session=session)
             # Once the task is done, break out
             if response.status_code != requests.codes.ACCEPTED:
                 break
@@ -161,18 +161,17 @@ def get_sse_stream(sut):
     try:
         # get the "before" set of EventDestination URIs
         if sut.subscriptions_uri:
-            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
+            r = sut.get(sut.subscriptions_uri)
             if r.status_code == requests.codes.OK:
                 data = get_response_json(r)
                 subs = set([m.get('@odata.id') for m in data.get('Members', [])
                             if '@odata.id' in m])
 
         if sut.server_sent_event_uri:
-            response = sut.session.get(sut.rhost + sut.server_sent_event_uri,
-                                       stream=True)
+            response = sut.get(sut.server_sent_event_uri, stream=True)
         if response is not None and response.ok and sut.subscriptions_uri:
             # get the "after" set of EventDestination URIs
-            r = sut.session.get(sut.rhost + sut.subscriptions_uri)
+            r = sut.get(sut.subscriptions_uri)
             if r.status_code == requests.codes.OK:
                 data = get_response_json(r)
                 new_subs = set([m.get('@odata.id') for m in

--- a/unittests/test_accounts.py
+++ b/unittests/test_accounts.py
@@ -128,7 +128,7 @@ class Accounts(TestCase):
         user, pwd, uri = accounts.add_account(self.sut, self.session)
         self.session.patch.assert_called_with(
             self.sut.rhost + self.account_uri3, json={'Enabled': True},
-            headers={'If-Match': etag})
+            headers={'If-Match': etag}, auth=None, timeout=30)
 
     @mock.patch('redfish_protocol_validator.accounts.logging.error')
     def test_add_account_via_patch_fail1(self, mock_logging_error):

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -371,10 +371,10 @@ class Resources(TestCase):
         headers = {'OData-Version': '4.0'}
         mock_get.return_value.status_code = requests.codes.OK
         resources.basic_auth_requests(self.sut)
-        mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri,
+        mock_get.assert_any_call(self.sut.sessions_uri,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),
-                                 verify=self.sut.verify)
+                                 no_session=True)
         responses = self.sut.get_responses_by_method(
             'GET', request_type=RequestType.BASIC_AUTH)
         self.assertEqual(len(responses), 2)

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -366,15 +366,15 @@ class Resources(TestCase):
         self.session.request.called_once_with(
             'DELETE', self.sut.rhost + '/redfish/v1/')
 
-    @mock.patch('redfish_protocol_validator.system_under_test.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
     def test_basic_auth_requests(self, mock_get):
         headers = {'OData-Version': '4.0'}
         mock_get.return_value.status_code = requests.codes.OK
         resources.basic_auth_requests(self.sut)
-        mock_get.assert_any_call(self.sut.sessions_uri,
+        mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),
-                                 no_session=True)
+                                 verify=self.sut.verify)
         responses = self.sut.get_responses_by_method(
             'GET', request_type=RequestType.BASIC_AUTH)
         self.assertEqual(len(responses), 2)

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -372,7 +372,7 @@ class Resources(TestCase):
         mock_get.return_value.status_code = requests.codes.OK
         resources.basic_auth_requests(self.sut)
         print(mock_get.mock_calls)
-        mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri,
+        mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri, json=None,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),
                                  stream=False, verify=self.sut.verify)

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -374,7 +374,7 @@ class Resources(TestCase):
         mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri, json=None,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),
-                                 stream=False, verify=self.sut.verify)
+                                 stream=False, verify=self.sut.verify, timeout=30)
         responses = self.sut.get_responses_by_method(
             'GET', request_type=RequestType.BASIC_AUTH)
         self.assertEqual(len(responses), 2)

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -366,15 +366,15 @@ class Resources(TestCase):
         self.session.request.called_once_with(
             'DELETE', self.sut.rhost + '/redfish/v1/')
 
-    @mock.patch('redfish_protocol_validator.sessions.requests.get')
+    @mock.patch('redfish_protocol_validator.system_under_test.get')
     def test_basic_auth_requests(self, mock_get):
         headers = {'OData-Version': '4.0'}
         mock_get.return_value.status_code = requests.codes.OK
         resources.basic_auth_requests(self.sut)
-        mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri,
+        mock_get.assert_any_call(self.sut.sessions_uri,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),
-                                 verify=self.sut.verify)
+                                 no_session=True)
         responses = self.sut.get_responses_by_method(
             'GET', request_type=RequestType.BASIC_AUTH)
         self.assertEqual(len(responses), 2)

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -371,6 +371,7 @@ class Resources(TestCase):
         headers = {'OData-Version': '4.0'}
         mock_get.return_value.status_code = requests.codes.OK
         resources.basic_auth_requests(self.sut)
+        print(mock_get.mock_calls)
         mock_get.assert_any_call(self.sut.sessions_uri,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -371,7 +371,6 @@ class Resources(TestCase):
         headers = {'OData-Version': '4.0'}
         mock_get.return_value.status_code = requests.codes.OK
         resources.basic_auth_requests(self.sut)
-        print(mock_get.mock_calls)
         mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri, json=None,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),

--- a/unittests/test_resources.py
+++ b/unittests/test_resources.py
@@ -366,16 +366,16 @@ class Resources(TestCase):
         self.session.request.called_once_with(
             'DELETE', self.sut.rhost + '/redfish/v1/')
 
-    @mock.patch('redfish_protocol_validator.system_under_test.requests.get')
+    @mock.patch('redfish_protocol_validator.sessions.requests.get')
     def test_basic_auth_requests(self, mock_get):
         headers = {'OData-Version': '4.0'}
         mock_get.return_value.status_code = requests.codes.OK
         resources.basic_auth_requests(self.sut)
         print(mock_get.mock_calls)
-        mock_get.assert_any_call(self.sut.sessions_uri,
+        mock_get.assert_any_call(self.sut.rhost + self.sut.sessions_uri,
                                  headers=headers, auth=(self.sut.username,
                                                         self.sut.password),
-                                 no_session=True)
+                                 stream=False, verify=self.sut.verify)
         responses = self.sut.get_responses_by_method(
             'GET', request_type=RequestType.BASIC_AUTH)
         self.assertEqual(len(responses), 2)

--- a/unittests/test_security_details.py
+++ b/unittests/test_security_details.py
@@ -1190,7 +1190,7 @@ class SecurityDetails(TestCase):
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + ro_uri,
             json={'AssignedPrivileges': test_priv},
-            headers={'If-Match': etag})
+            headers={'If-Match': etag}, auth=None, timeout=30)
         result = get_result(
             self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
             'PATCH', ro_uri)
@@ -1216,7 +1216,7 @@ class SecurityDetails(TestCase):
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + ro_uri,
             json={'AssignedPrivileges': privs},
-            headers={'If-Match': etag})
+            headers={'If-Match': etag}, auth=None, timeout=30)
         result = get_result(
             self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
             'PATCH', ro_uri)
@@ -1260,7 +1260,7 @@ class SecurityDetails(TestCase):
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + ro_uri,
             json={'AssignedPrivileges': ['Login', 'ConfigureSelf', None]},
-            headers={'If-Match': etag})
+            headers={'If-Match': etag}, auth=None, timeout=30)
         result = get_result(
             self.sut, Assertion.SEC_PRIV_PREDEFINED_ROLE_NOT_MODIFIABLE,
             'PATCH', ro_uri)

--- a/unittests/test_service_details.py
+++ b/unittests/test_service_details.py
@@ -263,12 +263,12 @@ class ServiceDetails(TestCase):
         self.mock_session.patch.assert_any_call(
             self.sut.rhost + self.sut.mgr_net_proto_uri,
             json={'SSDP': {'ProtocolEnabled': False}},
-            headers={'If-Match': 'abc'})
+            headers={'If-Match': 'abc'}, auth=None, timeout=30)
         # expected call to re-enable SSDP
         self.mock_session.patch.assert_called_with(
             self.sut.rhost + self.sut.mgr_net_proto_uri,
             json={'SSDP': {'ProtocolEnabled': True}},
-            headers={'If-Match': 'def'})
+            headers={'If-Match': 'def'}, auth=None, timeout=30)
 
     def test_test_ssdp_usn_matches_service_root_uuid_not_tested1(self):
         service.test_ssdp_usn_matches_service_root_uuid(self.sut)

--- a/unittests/test_service_requests.py
+++ b/unittests/test_service_requests.py
@@ -1588,7 +1588,7 @@ class ServiceRequests(TestCase):
         self.assertEqual(Result.PASS, result['result'])
         self.mock_session.delete.assert_called_with(
             self.sut.rhost + session_uri, json=None, headers=None, auth=None,
-            stream=False, timeout=30)
+            timeout=30)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_not_idempotent_not_tested1(self, mock_post):
@@ -1625,7 +1625,7 @@ class ServiceRequests(TestCase):
                       (uri, requests.codes.BAD_REQUEST), result['msg'])
         self.mock_session.delete.assert_called_with(
             self.sut.rhost + session_uri, json=None, headers=None, auth=None,
-            stream=False, timeout=30)
+            timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
@@ -1649,7 +1649,7 @@ class ServiceRequests(TestCase):
                       uri, result['msg'])
         self.mock_session.delete.assert_called_with(
             self.sut.rhost + session_uri, json=None, headers=None, auth=None,
-            stream=False, timeout=30)
+            timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
@@ -1673,7 +1673,7 @@ class ServiceRequests(TestCase):
                       session_uri, result['msg'])
         self.mock_session.delete.assert_called_with(
             self.sut.rhost + session_uri, json=None, headers=None, auth=None,
-            stream=False, timeout=30)
+            timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
@@ -1696,7 +1696,7 @@ class ServiceRequests(TestCase):
         self.assertEqual(Result.PASS, result['result'])
         self.mock_session.delete.assert_called_with(
             self.sut.rhost + session_uri1, json=None, headers=None, auth=None,
-            stream=False, timeout=30)
+            timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 2)
 
     def test_test_delete_method_required_not_tested(self):

--- a/unittests/test_service_requests.py
+++ b/unittests/test_service_requests.py
@@ -1587,7 +1587,8 @@ class ServiceRequests(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
         self.mock_session.delete.assert_called_with(
-            self.sut.rhost + session_uri, headers=None)
+            self.sut.rhost + session_uri, json=None, headers=None, auth=None,
+            stream=False, timeout=30)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
     def test_test_post_create_not_idempotent_not_tested1(self, mock_post):
@@ -1623,7 +1624,8 @@ class ServiceRequests(TestCase):
         self.assertIn('Second POST request to %s failed with status code %s' %
                       (uri, requests.codes.BAD_REQUEST), result['msg'])
         self.mock_session.delete.assert_called_with(
-            self.sut.rhost + session_uri, headers=None)
+            self.sut.rhost + session_uri, json=None, headers=None, auth=None,
+            stream=False, timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
@@ -1646,7 +1648,8 @@ class ServiceRequests(TestCase):
         self.assertIn('POST request to %s did not return a Location header' %
                       uri, result['msg'])
         self.mock_session.delete.assert_called_with(
-            self.sut.rhost + session_uri, headers=None)
+            self.sut.rhost + session_uri, json=None, headers=None, auth=None,
+            stream=False, timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
@@ -1669,7 +1672,8 @@ class ServiceRequests(TestCase):
         self.assertIn('the same resource URI in the Location header (%s)' %
                       session_uri, result['msg'])
         self.mock_session.delete.assert_called_with(
-            self.sut.rhost + session_uri, headers=None)
+            self.sut.rhost + session_uri, json=None, headers=None, auth=None,
+            stream=False, timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 1)
 
     @mock.patch('redfish_protocol_validator.service_requests.requests.post')
@@ -1691,7 +1695,8 @@ class ServiceRequests(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(Result.PASS, result['result'])
         self.mock_session.delete.assert_called_with(
-            self.sut.rhost + session_uri1, headers=None)
+            self.sut.rhost + session_uri1, json=None, headers=None, auth=None,
+            stream=False, timeout=30)
         self.assertEqual(self.mock_session.delete.call_count, 2)
 
     def test_test_delete_method_required_not_tested(self):

--- a/unittests/test_sessions.py
+++ b/unittests/test_sessions.py
@@ -61,7 +61,9 @@ class Sessions(TestCase):
         session.delete.return_value.status_code = requests.codes.OK
         sessions.delete_session(self.sut, session, uri)
         session.delete.assert_called_once_with(self.sut.rhost + uri,
-                                               headers=None)
+                                               json=None, headers=None,
+                                               auth=None, stream=False,
+                                               timeout=30)
 
     @mock.patch('redfish_protocol_validator.sessions.requests.Session')
     def test_no_auth_session(self, mock_session):

--- a/unittests/test_sessions.py
+++ b/unittests/test_sessions.py
@@ -62,8 +62,7 @@ class Sessions(TestCase):
         sessions.delete_session(self.sut, session, uri)
         session.delete.assert_called_once_with(self.sut.rhost + uri,
                                                json=None, headers=None,
-                                               auth=None, stream=False,
-                                               timeout=30)
+                                               auth=None, timeout=30)
 
     @mock.patch('redfish_protocol_validator.sessions.requests.Session')
     def test_no_auth_session(self, mock_session):


### PR DESCRIPTION
Still under development and test. This change is to give better reporting when exceptions are encountered during HTTP operations. Today the tool simply crashes, and this change will let the tool continue operating and be able to build a test report.

Fix #84 