### PR TITLE
Add ETag write-semantics tests

### DIFF
--- a/redfish_protocol_validator/console_scripts.py
+++ b/redfish_protocol_validator/console_scripts.py
@@ -13,6 +13,7 @@ import requests
 from urllib3.exceptions import InsecureRequestWarning
 from http.client import HTTPConnection
 
+from redfish_protocol_validator import etags
 from redfish_protocol_validator import protocol_details
 from redfish_protocol_validator import report
 from redfish_protocol_validator import resources
@@ -35,6 +36,7 @@ def perform_tests(sut: SystemUnderTest):
     service_responses.test_service_responses(sut)
     service_details.test_service_details(sut)
     security_details.test_security_details(sut)
+    etags.test_etags(sut)
 
 
 def main():

--- a/redfish_protocol_validator/constants.py
+++ b/redfish_protocol_validator/constants.py
@@ -79,6 +79,33 @@ class Assertion(NoValue):
         'ETags: Implementations shall support the return of ETag headers for GET requests of ManagerAccount resources.')
     PROTO_ETAG_RFC7232 = (
         'ETags: If a resource supports an ETag, it shall use the RFC7232-defined ETag.')
+    PROTO_ETAG_HEADER_AND_PROPERTY = (
+        'ETags: The service generates and provides the ETag as part of the resource payload in addition to the ETag '
+        'header; a client can include an ETag from a previous GET in the HTTP If-Match header, so the @odata.etag '
+        'property and the ETag header of a resource convey the same ETag.')
+    PROTO_ETAG_STABLE_WITHOUT_MODIFICATION = (
+        'ETags: Services should omit properties named DateTime from ETag calculations and should implement methods '
+        'to reduce the frequency of ETag updates for other types of fast changing properties.')
+    PROTO_ETAG_CONDITIONAL_GET = (
+        'ETags: If the ETag in the If-None-Match header matches the resource\'s current ETag, the GET operation '
+        'returns the HTTP 304 Not Modified status code. Support for If-None-Match is optional for services.')
+    PROTO_ETAG_IF_MATCH_ENFORCED = (
+        'ETags: To ensure that clients update the resource from a known state, PUT and PATCH requests for resources '
+        'for which a service returns ETags shall support If-Match: a request whose If-Match value matches the '
+        'resource\'s current ETag succeeds, and a request whose If-Match value does not match the resource\'s '
+        'current ETag fails with the HTTP 412 Precondition Failed status code.')
+    PROTO_ETAG_412_WRITE_NOT_APPLIED = (
+        'Modification error responses: If the service returns the HTTP 412 Precondition Failed status code for a PUT '
+        'or PATCH request, the service encountered a failed precondition and the resource shall not have been '
+        'modified as a result of the operation.')
+    PROTO_ETAG_LOST_UPDATE = (
+        'ETags: An ETag changes when the underlying object changes; an If-Match value read before an intervening '
+        'modification of the resource no longer matches the resource\'s current ETag, and a PUT or PATCH request '
+        'that provides it fails with the HTTP 412 Precondition Failed status code rather than overwriting the '
+        'intervening update.')
+    PROTO_ETAG_ROTATES_ON_WRITE = (
+        'ETags: An ETag is a hash, a generation ID, a time stamp, or some other value that changes when the '
+        'underlying object changes.')
     PROTO_STD_URI_SERVICE_ROOT = (
         'Protocol version: The root URI for this version of the Redfish protocol shall be /redfish/v1/.')
     PROTO_STD_URI_VERSION = (

--- a/redfish_protocol_validator/etags.py
+++ b/redfish_protocol_validator/etags.py
@@ -6,6 +6,7 @@
 import logging
 import threading
 import time
+from email.utils import parsedate_to_datetime
 
 import requests
 
@@ -171,9 +172,163 @@ def _classify_race(statuses):
     return winners, losers_412, losers_other, incomplete
 
 
-def _race_verdict(statuses, classification, race_etag):
+# Write-pairs attempted by the tag-resolution probe; each pair needs the
+# service to cooperate, so one coarse tag is usually caught on the first
+PROBE_PAIRS = 3
+# How far a numeric tag may sit from the response's own clock and still
+# be read as a wall-clock value, covering clock skew and the age of the
+# last write
+CLOCK_TAG_TOLERANCE_SEC = 300
+
+
+def _tag_tracks_the_clock(response, etag):
+    """Report whether the ETag looks like a wall-clock timestamp,
+    by comparing a numeric tag against the response's own Date header.
+
+    A clock tag cannot distinguish writes inside one tick; a non-clock
+    tag changes per write, so shared-tag winners got in because the
+    service let them. Returns None when either value cannot be read or
+    a numeric tag sits too far from the clock to classify.
+    """
+    date_header = response.headers.get('Date')
+    if not date_header or etag is None:
+        return None
+    try:
+        value = int(etag.strip().lstrip('Ww/').strip('"'))
+    except ValueError:
+        # A non-numeric tag is a hash or an opaque string, neither of
+        # which is a clock
+        return False
+    try:
+        served_at = parsedate_to_datetime(date_header).timestamp()
+    except (TypeError, ValueError):
+        return None
+    if abs(value - served_at) <= CLOCK_TAG_TOLERANCE_SEC:
+        return True
+    # Numeric but far from the clock is unknown: it could be a counter,
+    # or a last-modified timestamp on a resource idle longer than the
+    # tolerance
+    return None
+
+
+def _probe_write_and_read(sut: SystemUnderTest, acct_uri, role, etag):
+    """Apply a conditional write, returning (resulting tag, start time)."""
+    started = time.monotonic()
+    response = _patch_role(sut, acct_uri, role, etag)
+    if _succeeded(response):
+        response, new_etag, _ = _get_etags(sut, acct_uri)
+        if _succeeded(response):
+            return new_etag, started
+    return None, started
+
+
+def _probe_write_pair(sut: SystemUnderTest, acct_uri, current_role, etag):
+    """Run one write pair, flipping the role away and back so both
+    writes change the representation and the account ends as it began.
+
+    Returns (outcome, gap_ms, tag to continue from).
+    """
+    first, first_at = _probe_write_and_read(sut, acct_uri,
+                                            _other_role(current_role), etag)
+    if first is None:
+        return 'inconclusive', None, None
+    second, second_at = _probe_write_and_read(sut, acct_uri, current_role,
+                                              first)
+    gap_ms = int((second_at - first_at) * 1000)
+    if second is None:
+        return 'inconclusive', gap_ms, None
+    return ('coarse' if first == second else 'rotates'), gap_ms, second
+
+
+def _probe_tag_resolution(sut: SystemUnderTest, acct_uri):
+    """Determine whether the tag distinguishes two consecutive writes.
+
+    The same tag from two applied writes proves it cannot ('coarse').
+    Distinct tags only show the writes were far enough apart for this
+    tag ('rotates'), since the probe cannot write faster than the
+    service answers; gap_ms records the closest spacing achieved.
+
+    Returns ('coarse'|'rotates'|'inconclusive', gap_ms).
+    """
+    response, etag, _ = _get_etags(sut, acct_uri)
+    if not _succeeded(response) or etag is None:
+        return 'inconclusive', None
+    current_role = _role_of(response)
+    best_gap = None
+    for _ in range(PROBE_PAIRS):
+        outcome, gap_ms, etag = _probe_write_pair(sut, acct_uri,
+                                                  current_role, etag)
+        if gap_ms is not None and (best_gap is None or gap_ms < best_gap):
+            best_gap = gap_ms
+        if outcome != 'rotates':
+            return outcome, best_gap
+    return 'rotates', best_gap
+
+
+def _multi_winner_message(statuses, winners, race_etag, probe):
+    """Return the message naming which failure a multi-winner race is,
+    given the tag-resolution probe's outcome."""
+    prefix = ('%s of %s simultaneous PATCH requests carrying the same '
+              'If-Match value %s were accepted (statuses %s); ' %
+              (len(winners), RACE_WRITERS, race_etag, statuses))
+    outcome, gap_ms = probe
+    if outcome == 'not-a-clock':
+        return (prefix + 'the ETag does not track the service clock, so it '
+                'changes with the write rather than with the time, and it '
+                'would have distinguished these writers had the service '
+                'applied one write before checking the next precondition. '
+                'The precondition check and the write are not atomic; '
+                'writers with differing payloads would lose updates')
+    if outcome == 'coarse':
+        return (prefix + 'a follow-up probe found two writes %s ms apart '
+                'that produced the same ETag, so the tag cannot '
+                'distinguish writes this close together, no matter how the '
+                'service serializes them. An ETag built from a coarse '
+                'value, such as a second-granularity timestamp, behaves '
+                'this way' % gap_ms)
+    if outcome == 'clock':
+        return (prefix + 'the ETag tracks the service clock, so its '
+                'resolution bounds what a precondition can arbitrate and '
+                'writers inside one tick share a tag whatever the service '
+                'does. The tag is the defect this test can name; whether '
+                'the precondition check is also non-atomic is not '
+                'determined')
+    if outcome == 'rotates':
+        return (prefix + 'a follow-up probe saw consecutive writes produce '
+                'different ETags, but the closest it could space two '
+                'writes was %s ms, so it did not test whether the tag '
+                'distinguishes writes closer than that. Either the '
+                'precondition check is not atomic, or the tag is too '
+                'coarse for the interval the racing writers achieved'
+                % gap_ms)
+    return (prefix + 'either the precondition check and the write are not '
+            'atomic, or the tag is too coarse to distinguish writes this '
+            'close together; a follow-up probe could not determine which')
+
+
+def _diagnose_multi_winner(sut: SystemUnderTest, acct_uri, race_etag):
+    """Name the cause of a race that admitted more than one winner:
+    a non-clock tag would have separated the writers, so the failure is
+    atomicity; a clock tag falls to the slower write-pair probe.
+
+    Returns the (outcome, gap_ms) pair _race_verdict() reports on.
+    """
+    response = sut.get(acct_uri)
+    is_clock = _tag_tracks_the_clock(response, race_etag)
+    if is_clock is False:
+        return 'not-a-clock', None
+    outcome, gap_ms = _probe_tag_resolution(sut, acct_uri)
+    if outcome == 'rotates' and is_clock:
+        outcome = 'clock'
+    return outcome, gap_ms
+
+
+def _race_verdict(statuses, classification, race_etag, probe):
     """Return (Result, message) for a race outcome, or None when the race
     produced one clean winner whose write the caller still has to verify.
+
+    probe is the _probe_tag_resolution() outcome, needed only to name
+    which failure a multi-winner race is; pass None otherwise.
     """
     winners, losers_412, losers_other, incomplete = classification
     throttled = [i for i in losers_other
@@ -181,10 +336,7 @@ def _race_verdict(statuses, classification, race_etag):
 
     if len(winners) > 1:
         return (Result.FAIL,
-                '%s of %s simultaneous PATCH requests carrying the same '
-                'If-Match value %s were accepted (statuses %s); at most '
-                'one conditional write may succeed against a single ETag'
-                % (len(winners), RACE_WRITERS, race_etag, statuses))
+                _multi_winner_message(statuses, winners, race_etag, probe))
     if incomplete:
         # A verdict about the connection, not the service
         return (Result.NOT_TESTED,
@@ -499,7 +651,13 @@ def test_concurrent_conditional_writes(sut: SystemUnderTest, acct_uri):
     classification = _classify_race(statuses)
     winners, losers_412, _, _ = classification
 
-    verdict = _race_verdict(statuses, classification, race_etag)
+    if len(winners) > 1:
+        # A failure whether or not the other writers completed; a 202
+        # counts as accepted
+        probe = _diagnose_multi_winner(sut, acct_uri, race_etag)
+    else:
+        probe = None
+    verdict = _race_verdict(statuses, classification, race_etag, probe)
     if verdict is not None:
         result, msg = verdict
         status = statuses[winners[0]] if winners else ''

--- a/redfish_protocol_validator/etags.py
+++ b/redfish_protocol_validator/etags.py
@@ -1,0 +1,598 @@
+# Copyright Notice:
+# Copyright 2026 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link:
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/main/LICENSE.md
+
+import logging
+import threading
+import time
+
+import requests
+
+from redfish_protocol_validator import accounts
+from redfish_protocol_validator import utils
+from redfish_protocol_validator.constants import Assertion, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
+
+# A syntactically valid ETag that no service will ever have issued
+NEVER_ISSUED_ETAG = '"rpv-never-issued-etag"'
+# Delay between the two reads of the ETag stability test
+STABILITY_DELAY_SEC = 2
+# Number of concurrent writers in the conditional-write race
+RACE_WRITERS = 4
+# Status codes that indicate the service throttled or serialized the
+# concurrent writers rather than evaluating their preconditions
+RACE_THROTTLE_CODES = (
+    requests.codes.UNAUTHORIZED,
+    requests.codes.TOO_MANY_REQUESTS,
+    requests.codes.SERVICE_UNAVAILABLE,
+)
+
+# RoleId is readable, so every write is observable and a
+# representation-derived ETag changes with it; Password renders as
+# null. Administrator is never used, so a leaked account cannot hold it.
+WRITE_ROLES = ('Operator', 'ReadOnly')
+
+ETAG_ASSERTIONS = [
+    Assertion.PROTO_ETAG_HEADER_AND_PROPERTY,
+    Assertion.PROTO_ETAG_STABLE_WITHOUT_MODIFICATION,
+    Assertion.PROTO_ETAG_CONDITIONAL_GET,
+    Assertion.PROTO_ETAG_IF_MATCH_ENFORCED,
+    Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED,
+    Assertion.PROTO_ETAG_LOST_UPDATE,
+    Assertion.PROTO_ETAG_ROTATES_ON_WRITE,
+]
+
+
+def _succeeded(response):
+    """Report whether a response carries a success status.
+
+    Response.ok cannot be used here: the system-under-test synthesizes
+    status 600 for a request that raised a transport exception, and
+    raise_for_status only raises for 4xx and 5xx, so ok is True for it.
+    """
+    return 200 <= response.status_code < 300
+
+
+def _evaluated(status):
+    """Report whether the service evaluated the request.
+
+    A 401 was refused before the precondition was considered; a
+    synthesized transport failure (600+) lost its outcome, and the
+    write can still have been applied.
+    """
+    return status < 600 and status != requests.codes.UNAUTHORIZED
+
+
+def _get_etags(sut: SystemUnderTest, uri):
+    """GET uri and return (response, header ETag, @odata.etag property)."""
+    response = sut.get(uri)
+    header_etag, body_etag = None, None
+    if _succeeded(response):
+        header_etag = response.headers.get('ETag')
+        if utils.get_response_media_type(response) == 'application/json':
+            body_etag = utils.get_response_json(response).get('@odata.etag')
+    return response, header_etag, body_etag
+
+
+def _role_of(response):
+    """Return the RoleId from an account response, or None."""
+    if utils.get_response_media_type(response) == 'application/json':
+        return utils.get_response_json(response).get('RoleId')
+    return None
+
+
+def _other_role(role):
+    """Return the write role that differs from the given role;
+    anything outside the pair flips to ReadOnly, never upward."""
+    if role == WRITE_ROLES[1]:
+        return WRITE_ROLES[0]
+    return WRITE_ROLES[1]
+
+
+def _patch_role(sut: SystemUnderTest, acct_uri, role, etag):
+    """PATCH the account RoleId with the given If-Match value.
+
+    The ETag is sent verbatim, weak prefix included; services should
+    perform weak comparison when verifying client-supplied ETags.
+    """
+    return sut.patch(acct_uri, json={'RoleId': role},
+                     headers={'If-Match': etag})
+
+
+def _verify_role(sut: SystemUnderTest, acct_uri, expected_role):
+    """GET the account and compare its RoleId to the expected role.
+
+    Returns (verdict, detail); verdict is None when the read did not
+    answer, so a broken channel is never read as a definite outcome.
+    """
+    response = sut.get(acct_uri)
+    if not _succeeded(response):
+        return None, 'the verification GET returned status %s' % (
+            response.status_code)
+    role = _role_of(response)
+    if role is None:
+        return None, 'the verification GET returned no RoleId property'
+    return role == expected_role, "the account's RoleId is '%s'" % role
+
+
+def _race_conditional_writes(sut: SystemUnderTest, acct_uri, etag, role):
+    """Fire simultaneous PATCH requests that carry the same If-Match.
+
+    Connections are pre-warmed so the racing requests do not serialize
+    behind TCP/TLS setup. Every writer requests the same role: RoleId
+    has too few values for per-writer attribution, so the race checks
+    for one acceptance. Returns one response (or None) per writer.
+    """
+    barrier = threading.Barrier(RACE_WRITERS, timeout=60)
+    responses = [None] * RACE_WRITERS
+
+    def writer(index):
+        session = requests.Session()
+        session.auth = (sut.username, sut.password)
+        session.verify = sut.verify
+        try:
+            session.get(sut.rhost + acct_uri, timeout=30)
+            barrier.wait()
+            responses[index] = session.patch(
+                sut.rhost + acct_uri,
+                json={'RoleId': role},
+                headers={'If-Match': etag}, timeout=30)
+        except Exception as e:
+            logging.warning('Concurrent conditional PATCH %s raised %s: %s'
+                            % (index, e.__class__.__name__, e))
+        finally:
+            session.close()
+
+    threads = [threading.Thread(target=writer, args=(i,))
+               for i in range(RACE_WRITERS)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    return responses
+
+
+def _classify_race(statuses):
+    """Split race statuses into (winners, losers_412, losers_other,
+    incomplete) index lists; None means the request never completed,
+    which is never a verdict about the service.
+    """
+    winners, losers_412, losers_other, incomplete = [], [], [], []
+    for index, status in enumerate(statuses):
+        if status is None:
+            incomplete.append(index)
+        elif 200 <= status < 300:
+            winners.append(index)
+        elif status == requests.codes.PRECONDITION_FAILED:
+            losers_412.append(index)
+        else:
+            losers_other.append(index)
+    return winners, losers_412, losers_other, incomplete
+
+
+def _race_verdict(statuses, classification, race_etag):
+    """Return (Result, message) for a race outcome, or None when the race
+    produced one clean winner whose write the caller still has to verify.
+    """
+    winners, losers_412, losers_other, incomplete = classification
+    throttled = [i for i in losers_other
+                 if statuses[i] in RACE_THROTTLE_CODES]
+
+    if len(winners) > 1:
+        return (Result.FAIL,
+                '%s of %s simultaneous PATCH requests carrying the same '
+                'If-Match value %s were accepted (statuses %s); at most '
+                'one conditional write may succeed against a single ETag'
+                % (len(winners), RACE_WRITERS, race_etag, statuses))
+    if incomplete:
+        # A verdict about the connection, not the service
+        return (Result.NOT_TESTED,
+                '%s of %s simultaneous PATCH requests did not complete '
+                '(connection failure or timeout; statuses %s); unable to '
+                'fully exercise conditional-write atomicity'
+                % (len(incomplete), RACE_WRITERS, statuses))
+    if losers_other and len(throttled) == len(losers_other):
+        return (Result.NOT_TESTED,
+                'The service throttled or refused concurrent requests '
+                '(statuses %s); atomicity could not be fully exercised'
+                % (statuses,))
+    if losers_other:
+        if winners:
+            return (Result.FAIL,
+                    'Losing simultaneous PATCH requests must be rejected '
+                    'with 412 Precondition Failed; got statuses %s'
+                    % (statuses,))
+        return (Result.NOT_TESTED,
+                'Unable to exercise simultaneous conditional writes; '
+                'requests returned unexpected statuses %s' % (statuses,))
+    if not winners:
+        return (Result.FAIL,
+                'No simultaneous PATCH request succeeded; every writer was '
+                'rejected with 412 against the ETag it had just read '
+                '(statuses %s)' % (statuses,))
+    return None
+
+
+def test_header_and_property(sut: SystemUnderTest, acct_uri, header_etag,
+                             body_etag):
+    """Perform tests for Assertion.PROTO_ETAG_HEADER_AND_PROPERTY."""
+    # Exact comparison is safe: the system under test sends
+    # Accept-Encoding: identity, so no content coding varies the header
+    # tag from the property (RFC 7232)
+    if body_etag is None:
+        msg = ('Resource returned the ETag header %s but no @odata.etag '
+               'property' % header_etag)
+        sut.log(Result.WARN, 'GET', requests.codes.OK, acct_uri,
+                Assertion.PROTO_ETAG_HEADER_AND_PROPERTY, msg)
+    elif body_etag != header_etag:
+        msg = ('The @odata.etag property %s does not equal the ETag header '
+               '%s; a client that builds If-Match from one of them will '
+               'fail the precondition' % (body_etag, header_etag))
+        sut.log(Result.WARN, 'GET', requests.codes.OK, acct_uri,
+                Assertion.PROTO_ETAG_HEADER_AND_PROPERTY, msg)
+    else:
+        sut.log(Result.PASS, 'GET', requests.codes.OK, acct_uri,
+                Assertion.PROTO_ETAG_HEADER_AND_PROPERTY, 'Test passed')
+
+
+def test_etag_stability(sut: SystemUnderTest, acct_uri, header_etag):
+    """Perform tests for Assertion.PROTO_ETAG_STABLE_WITHOUT_MODIFICATION."""
+    time.sleep(STABILITY_DELAY_SEC)
+    response, reread_etag, _ = _get_etags(sut, acct_uri)
+    if not _succeeded(response) or reread_etag is None:
+        msg = ('GET request to %s failed or returned no ETag on the second '
+               'read; unable to test this assertion' % acct_uri)
+        sut.log(Result.NOT_TESTED, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_STABLE_WITHOUT_MODIFICATION, msg)
+        return
+    if reread_etag != header_etag:
+        msg = ('ETag changed from %s to %s across reads %s seconds apart '
+               'with no intervening write; an ETag that changes without a '
+               'modification, such as one calculated over a DateTime '
+               'property, cannot satisfy an If-Match precondition built '
+               'from a recent read' %
+               (header_etag, reread_etag, STABILITY_DELAY_SEC))
+        sut.log(Result.WARN, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_STABLE_WITHOUT_MODIFICATION, msg)
+    else:
+        sut.log(Result.PASS, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_STABLE_WITHOUT_MODIFICATION,
+                'Test passed')
+
+
+def test_conditional_get(sut: SystemUnderTest, acct_uri, header_etag):
+    """Perform tests for Assertion.PROTO_ETAG_CONDITIONAL_GET."""
+    response = sut.get(acct_uri, headers={'If-None-Match': header_etag})
+    if response.status_code == requests.codes.NOT_MODIFIED:
+        sut.log(Result.PASS, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_CONDITIONAL_GET, 'Test passed')
+    elif not _evaluated(response.status_code):
+        msg = ('Conditional GET returned status %s; the credential was '
+               'refused before the precondition was considered, or the '
+               'outcome was lost in transport' % response.status_code)
+        sut.log(Result.NOT_TESTED, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_CONDITIONAL_GET, msg)
+    elif _succeeded(response):
+        msg = ('GET with a matching If-None-Match header returned %s with a '
+               'full body; expected 304 Not Modified. Support for '
+               'If-None-Match is optional, but without it clients cannot '
+               'revalidate a resource without transferring it' %
+               response.status_code)
+        sut.log(Result.WARN, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_CONDITIONAL_GET, msg)
+    else:
+        msg = ('GET with a matching If-None-Match header failed with status '
+               '%s; extended error: %s' %
+               (response.status_code, utils.get_extended_error(response)))
+        sut.log(Result.WARN, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_CONDITIONAL_GET, msg)
+
+
+def test_never_issued_etag_rejected(sut: SystemUnderTest, acct_uri,
+                                    current_role):
+    """Perform the never-issued If-Match tests for
+    Assertion.PROTO_ETAG_IF_MATCH_ENFORCED and
+    Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED."""
+    response = _patch_role(sut, acct_uri, _other_role(current_role),
+                           NEVER_ISSUED_ETAG)
+    if not _evaluated(response.status_code):
+        msg = ('PATCH with a never-issued If-Match value returned status '
+               '%s; the credential was refused before the precondition was '
+               'considered, or the outcome was lost in transport' %
+               response.status_code)
+        sut.log(Result.NOT_TESTED, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        sut.log(Result.NOT_TESTED, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED, msg)
+        return
+    if response.status_code != requests.codes.PRECONDITION_FAILED:
+        if _succeeded(response):
+            msg = ('PATCH with If-Match value %s, which the service never '
+                   'issued, succeeded with status %s; expected 412 '
+                   'Precondition Failed' %
+                   (NEVER_ISSUED_ETAG, response.status_code))
+        else:
+            # Still a failure: RFC 9110 evaluates preconditions before
+            # request content, so a content error cannot displace the 412
+            msg = ('PATCH with If-Match value %s, which the service never '
+                   'issued, returned status %s rather than a write '
+                   'acceptance; expected 412 Precondition Failed; '
+                   'extended error: %s' %
+                   (NEVER_ISSUED_ETAG, response.status_code,
+                    utils.get_extended_error(response)))
+        sut.log(Result.FAIL, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        return
+    sut.log(Result.PASS, 'PATCH', response.status_code, acct_uri,
+            Assertion.PROTO_ETAG_IF_MATCH_ENFORCED,
+            'Test passed for never-issued If-Match value')
+    verdict, detail = _verify_role(sut, acct_uri, current_role)
+    if verdict:
+        sut.log(Result.PASS, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED, 'Test passed')
+    elif verdict is None:
+        msg = ('PATCH was rejected with 412, but %s; unable to determine '
+               'whether the rejected write was applied' % detail)
+        sut.log(Result.NOT_TESTED, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED, msg)
+    else:
+        msg = ('PATCH was rejected with 412, but %s rather than the prior '
+               "'%s'; the rejected write was applied" %
+               (detail, current_role))
+        sut.log(Result.FAIL, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED, msg)
+
+
+def test_current_etag_accepted(sut: SystemUnderTest, acct_uri):
+    """Perform the matching If-Match tests for
+    Assertion.PROTO_ETAG_IF_MATCH_ENFORCED.
+
+    Returns (pre-write ETag, the role written) on success, (etag, None)
+    otherwise.
+    """
+    response, pre_write_etag, _ = _get_etags(sut, acct_uri)
+    if not _succeeded(response) or pre_write_etag is None:
+        msg = ('GET request to %s failed or returned no ETag header to use '
+               'for If-Match; unable to test this assertion' % acct_uri)
+        sut.log(Result.NOT_TESTED, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        return None, None
+    new_role = _other_role(_role_of(response))
+    response = _patch_role(sut, acct_uri, new_role, pre_write_etag)
+    if not _evaluated(response.status_code):
+        msg = ('PATCH with the current ETag %s in If-Match returned status '
+               '%s; the credential was refused before the precondition was '
+               'considered, or the outcome was lost in transport' %
+               (pre_write_etag, response.status_code))
+        sut.log(Result.NOT_TESTED, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        return pre_write_etag, None
+    if not _succeeded(response):
+        msg = ('PATCH with the current ETag %s in If-Match returned status '
+               '%s; expected success; extended error: %s' %
+               (pre_write_etag, response.status_code,
+                utils.get_extended_error(response)))
+        sut.log(Result.FAIL, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        return pre_write_etag, None
+    verdict, detail = _verify_role(sut, acct_uri, new_role)
+    if not verdict:
+        if verdict is None:
+            msg = ('PATCH with the current ETag %s in If-Match returned '
+                   'status %s, but %s; unable to verify the write' %
+                   (pre_write_etag, response.status_code, detail))
+            sut.log(Result.NOT_TESTED, 'PATCH', response.status_code,
+                    acct_uri, Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        elif response.status_code == requests.codes.ACCEPTED:
+            msg = ('PATCH with the current ETag %s in If-Match was accepted '
+                   'asynchronously (202) and the write is not yet '
+                   'observable' % pre_write_etag)
+            sut.log(Result.WARN, 'PATCH', response.status_code, acct_uri,
+                    Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        else:
+            msg = ('PATCH with the current ETag %s in If-Match returned '
+                   "status %s, but %s rather than the requested '%s'" %
+                   (pre_write_etag, response.status_code, detail, new_role))
+            sut.log(Result.FAIL, 'PATCH', response.status_code, acct_uri,
+                    Assertion.PROTO_ETAG_IF_MATCH_ENFORCED, msg)
+        return pre_write_etag, None
+    sut.log(Result.PASS, 'PATCH', response.status_code, acct_uri,
+            Assertion.PROTO_ETAG_IF_MATCH_ENFORCED,
+            'Test passed for matching If-Match value')
+    return pre_write_etag, new_role
+
+
+def test_lost_update_prevented(sut: SystemUnderTest, acct_uri,
+                               pre_write_etag, current_role):
+    """Perform tests for Assertion.PROTO_ETAG_LOST_UPDATE."""
+    response = _patch_role(sut, acct_uri, _other_role(current_role),
+                           pre_write_etag)
+    if not _evaluated(response.status_code):
+        msg = ('PATCH replaying the stale If-Match value %s returned status '
+               '%s; the credential was refused before the precondition was '
+               'considered, or the outcome was lost in transport' %
+               (pre_write_etag, response.status_code))
+        sut.log(Result.NOT_TESTED, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_LOST_UPDATE, msg)
+        return
+    if response.status_code != requests.codes.PRECONDITION_FAILED:
+        if _succeeded(response):
+            msg = ('PATCH with If-Match value %s, which was read before an '
+                   'intervening write and is now stale, succeeded with '
+                   'status %s; expected 412 Precondition Failed. Two '
+                   'writers that hold the same ETag can silently overwrite '
+                   'each other\'s update' %
+                   (pre_write_etag, response.status_code))
+        else:
+            msg = ('PATCH with the stale If-Match value %s returned status '
+                   '%s; expected 412 Precondition Failed; extended error: '
+                   '%s' % (pre_write_etag, response.status_code,
+                           utils.get_extended_error(response)))
+        sut.log(Result.FAIL, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_LOST_UPDATE, msg)
+        return
+    verdict, detail = _verify_role(sut, acct_uri, current_role)
+    if verdict:
+        sut.log(Result.PASS, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_LOST_UPDATE, 'Test passed')
+    elif verdict is None:
+        msg = ('The stale If-Match value was rejected with 412, but %s; '
+               'unable to determine whether the rejected write was applied'
+               % detail)
+        sut.log(Result.NOT_TESTED, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_LOST_UPDATE, msg)
+    else:
+        msg = ('The stale If-Match value was rejected with 412, but %s '
+               "rather than the intervening write's '%s'; the rejected "
+               'write was applied' % (detail, current_role))
+        sut.log(Result.FAIL, 'PATCH', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_LOST_UPDATE, msg)
+
+
+def test_etag_rotates_on_write(sut: SystemUnderTest, acct_uri,
+                               pre_write_etag):
+    """Perform tests for Assertion.PROTO_ETAG_ROTATES_ON_WRITE.
+
+    Returns the post-write ETag, or None if it could not be read.
+    """
+    response, post_write_etag, _ = _get_etags(sut, acct_uri)
+    if not _succeeded(response) or post_write_etag is None:
+        msg = ('GET request to %s failed or returned no ETag after a '
+               'successful PATCH; unable to test this assertion' % acct_uri)
+        sut.log(Result.NOT_TESTED, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_ROTATES_ON_WRITE, msg)
+        return None
+    if post_write_etag == pre_write_etag:
+        msg = ('ETag %s did not change after a successful PATCH that '
+               'changed the RoleId property; an ETag that survives an '
+               'observable modification cannot invalidate stale copies '
+               'held by other clients' % pre_write_etag)
+        sut.log(Result.WARN, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_ROTATES_ON_WRITE, msg)
+    else:
+        sut.log(Result.PASS, 'GET', response.status_code, acct_uri,
+                Assertion.PROTO_ETAG_ROTATES_ON_WRITE, 'Test passed')
+    return post_write_etag
+
+
+def test_concurrent_conditional_writes(sut: SystemUnderTest, acct_uri):
+    """Perform the conditional-write race test for
+    Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS.
+
+    Same If-Match on every writer; exactly one must win and the rest
+    draw 412. One round only, so a PASS bounds rather than proves
+    atomicity.
+    """
+    assertion = Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS
+    response, race_etag, _ = _get_etags(sut, acct_uri)
+    if not _succeeded(response) or race_etag is None:
+        msg = ('GET request to %s failed or returned no ETag header to use '
+               'for If-Match; unable to test this assertion' % acct_uri)
+        sut.log(Result.NOT_TESTED, 'GET', response.status_code, acct_uri,
+                assertion, msg)
+        return
+    target_role = _other_role(_role_of(response))
+    responses = _race_conditional_writes(sut, acct_uri, race_etag,
+                                         target_role)
+    statuses = [r.status_code if r is not None else None for r in responses]
+    classification = _classify_race(statuses)
+    winners, losers_412, _, _ = classification
+
+    verdict = _race_verdict(statuses, classification, race_etag)
+    if verdict is not None:
+        result, msg = verdict
+        status = statuses[winners[0]] if winners else ''
+        sut.log(result, 'PATCH', status, acct_uri, assertion, msg)
+        return
+    role_verdict, detail = _verify_role(sut, acct_uri, target_role)
+    if role_verdict:
+        msg = ('Test passed: %s simultaneous conditional writes, one '
+               'winner, %s rejected with 412' %
+               (RACE_WRITERS, len(losers_412)))
+        sut.log(Result.PASS, 'PATCH', statuses[winners[0]], acct_uri,
+                assertion, msg)
+    elif (role_verdict is False and
+            statuses[winners[0]] == requests.codes.ACCEPTED):
+        msg = ('The winning PATCH was accepted asynchronously (202) and '
+               'the write is not yet observable')
+        sut.log(Result.WARN, 'PATCH', statuses[winners[0]], acct_uri,
+                assertion, msg)
+    elif role_verdict is None:
+        msg = ('Exactly one simultaneous PATCH succeeded, but %s; unable '
+               'to verify the winning write' % detail)
+        sut.log(Result.NOT_TESTED, 'PATCH', statuses[winners[0]], acct_uri,
+                assertion, msg)
+    else:
+        msg = ('Exactly one simultaneous PATCH succeeded, but %s rather '
+               "than the requested '%s'" % (detail, target_role))
+        sut.log(Result.FAIL, 'PATCH', statuses[winners[0]], acct_uri,
+                assertion, msg)
+
+
+def test_etags(sut: SystemUnderTest):
+    """Perform live ETag write-semantics tests against a temporary
+    ManagerAccount, the one resource where ETag support is required
+    (sections 6.5, 7.1, and 13.5.1). Writes flip RoleId between two
+    standard roles and are verified by reading the property back.
+    """
+    user, password, acct_uri = accounts.add_account(sut, sut.session)
+    if not acct_uri:
+        msg = ('Failed to create an account to test ETag write semantics; '
+               'unable to test these assertions')
+        for assertion in ETAG_ASSERTIONS:
+            sut.log(Result.NOT_TESTED, '', '', '', assertion, msg)
+        sut.log(Result.NOT_TESTED, '', '', '',
+                Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS, msg)
+        return
+    try:
+        response, header_etag, body_etag = _get_etags(sut, acct_uri)
+        if not _succeeded(response) or header_etag is None:
+            # ETag presence on ManagerAccount GETs is scored by
+            # PROTO_ETAG_ON_GET_ACCOUNT; without a tag there is no
+            # write-semantics contract to test
+            msg = ('GET request to %s did not return an ETag header; '
+                   'unable to test this assertion' % acct_uri)
+            for assertion in ETAG_ASSERTIONS:
+                sut.log(Result.NOT_TESTED, 'GET', response.status_code,
+                        acct_uri, assertion, msg)
+            sut.log(Result.NOT_TESTED, 'GET', response.status_code,
+                    acct_uri, Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS, msg)
+            return
+        initial_role = _role_of(response)
+        if initial_role is None:
+            # Without the property the write tests can neither pick a
+            # role nor verify one
+            msg = ('GET request to %s did not return a RoleId property; '
+                   'unable to verify writes for this assertion' % acct_uri)
+            for assertion in [Assertion.PROTO_ETAG_IF_MATCH_ENFORCED,
+                              Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED,
+                              Assertion.PROTO_ETAG_LOST_UPDATE,
+                              Assertion.PROTO_ETAG_ROTATES_ON_WRITE]:
+                sut.log(Result.NOT_TESTED, 'GET', response.status_code,
+                        acct_uri, assertion, msg)
+            sut.log(Result.NOT_TESTED, 'GET', response.status_code,
+                    acct_uri, Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS, msg)
+            test_header_and_property(sut, acct_uri, header_etag, body_etag)
+            test_etag_stability(sut, acct_uri, header_etag)
+            test_conditional_get(sut, acct_uri, header_etag)
+            return
+        test_header_and_property(sut, acct_uri, header_etag, body_etag)
+        test_etag_stability(sut, acct_uri, header_etag)
+        test_conditional_get(sut, acct_uri, header_etag)
+        test_never_issued_etag_rejected(sut, acct_uri, initial_role)
+        pre_write_etag, new_role = test_current_etag_accepted(sut, acct_uri)
+        if new_role:
+            test_lost_update_prevented(sut, acct_uri, pre_write_etag,
+                                       new_role)
+            test_etag_rotates_on_write(sut, acct_uri, pre_write_etag)
+        else:
+            msg = ('PATCH with the current ETag in If-Match did not '
+                   'observably succeed; unable to test this assertion')
+            sut.log(Result.NOT_TESTED, '', '', acct_uri,
+                    Assertion.PROTO_ETAG_LOST_UPDATE, msg)
+            sut.log(Result.NOT_TESTED, '', '', acct_uri,
+                    Assertion.PROTO_ETAG_ROTATES_ON_WRITE, msg)
+        test_concurrent_conditional_writes(sut, acct_uri)
+    finally:
+        accounts.delete_account(sut, sut.session, user, acct_uri)

--- a/unittests/test_etags.py
+++ b/unittests/test_etags.py
@@ -1,0 +1,515 @@
+# Copyright Notice:
+# Copyright 2026 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link:
+# https://github.com/DMTF/Redfish-Protocol-Validator/blob/main/LICENSE.md
+
+import unittest
+from unittest import mock, TestCase
+
+import requests
+
+from redfish_protocol_validator import etags
+from redfish_protocol_validator.constants import Assertion, Result
+from redfish_protocol_validator.system_under_test import SystemUnderTest
+
+ACCT_URI = '/redfish/v1/AccountService/Accounts/9'
+USER = 'rfpvtest'
+PASSWORD = 'OrigPass1_'
+
+# The GETs test_etags() performs in order, for building mock sequences
+# by name rather than by index
+GET_SLOTS = (
+    'initial',
+    'stability',
+    'conditional_get',
+    'verify_after_412',
+    'pre_write',
+    'verify_new_role',
+    'verify_after_replay',
+    'rotation',
+    'race_read',
+    'verify_race_winner',
+)
+
+
+def _response(status_code=200, etag=None, body_etag=None, role=None):
+    resp = mock.MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    # Mirror requests: raise_for_status raises only for 4xx and 5xx, so
+    # ok is True for the 600 the SUT synthesizes from a transport
+    # exception
+    resp.ok = not (400 <= status_code < 600)
+    headers = {'Content-Type': 'application/json'}
+    if etag is not None:
+        headers['ETag'] = etag
+    resp.headers = headers
+    body = {}
+    if body_etag is not None:
+        body['@odata.etag'] = body_etag
+    if role is not None:
+        body['RoleId'] = role
+    resp.json.return_value = body
+    return resp
+
+
+class EtagsNoSut(TestCase):
+    """Tests for the pure helpers."""
+
+    def test_succeeded_rejects_synthesized_transport_status(self):
+        # The SUT builds a 600 response from a transport exception, and
+        # Response.ok is True for it because raise_for_status only
+        # raises for 4xx and 5xx
+        self.assertTrue(_response(200).ok)
+        self.assertTrue(_response(600).ok)
+        self.assertTrue(etags._succeeded(_response(200)))
+        self.assertFalse(etags._succeeded(_response(600)))
+        self.assertFalse(etags._succeeded(_response(304)))
+
+    def test_evaluated(self):
+        self.assertTrue(etags._evaluated(412))
+        self.assertTrue(etags._evaluated(500))
+        self.assertFalse(etags._evaluated(401))
+        self.assertFalse(etags._evaluated(600))
+
+    def test_other_role(self):
+        self.assertEqual(etags._other_role('Operator'), 'ReadOnly')
+        self.assertEqual(etags._other_role('ReadOnly'), 'Operator')
+        # any role outside the write pair flips to ReadOnly, never upward
+        self.assertEqual(etags._other_role('Administrator'), 'ReadOnly')
+        self.assertEqual(etags._other_role(None), 'ReadOnly')
+
+    def verdict(self, statuses, race_etag='"E1"'):
+        return etags._race_verdict(statuses, etags._classify_race(statuses),
+                                   race_etag)
+
+    def test_race_verdict_clean_winner_defers(self):
+        self.assertIsNone(self.verdict([412, 200, 412, 412]))
+
+    def test_race_verdict_multi_winner_fails(self):
+        result, msg = self.verdict([200, 200, 412, 412])
+        self.assertEqual(result, Result.FAIL)
+        self.assertIn('at most one conditional write may succeed', msg)
+
+    def test_race_verdict_incomplete_and_throttled(self):
+        self.assertEqual(self.verdict([200, 412, 412, None])[0],
+                         Result.NOT_TESTED)
+        self.assertEqual(self.verdict([200, 503, 412, 412])[0],
+                         Result.NOT_TESTED)
+
+    def test_race_verdict_failures(self):
+        self.assertEqual(self.verdict([412, 412, 412, 412])[0], Result.FAIL)
+        self.assertEqual(self.verdict([200, 500, 412, 412])[0], Result.FAIL)
+
+    def test_classify_race_one_winner(self):
+        winners, losers_412, losers_other, incomplete = etags._classify_race(
+            [412, 200, 412, 412])
+        self.assertEqual(winners, [1])
+        self.assertEqual(losers_412, [0, 2, 3])
+        self.assertEqual(losers_other, [])
+        self.assertEqual(incomplete, [])
+
+    def test_classify_race_two_winners(self):
+        winners, losers_412, losers_other, incomplete = etags._classify_race(
+            [200, 204, 412, 412])
+        self.assertEqual(winners, [0, 1])
+        self.assertEqual(losers_412, [2, 3])
+        self.assertEqual(losers_other, [])
+        self.assertEqual(incomplete, [])
+
+    def test_classify_race_throttled_and_incomplete(self):
+        winners, losers_412, losers_other, incomplete = etags._classify_race(
+            [200, 503, 412, None])
+        self.assertEqual(winners, [0])
+        self.assertEqual(losers_412, [2])
+        self.assertEqual(losers_other, [1])
+        self.assertEqual(incomplete, [3])
+
+
+class Etags(TestCase):
+
+    def setUp(self):
+        super(Etags, self).setUp()
+        self.sut = SystemUnderTest('https://127.0.0.1:8000', 'oper', 'xyzzy')
+        patcher = mock.patch(
+            'redfish_protocol_validator.etags.accounts', autospec=True)
+        self.mock_accounts = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.mock_accounts.add_account.return_value = (
+            USER, PASSWORD, ACCT_URI)
+
+    def result(self, assertion):
+        return [entry['result'] for entry in
+                self.sut.results.get(assertion, [])]
+
+    def happy_path_gets(self, **overrides):
+        """The GET sequence of a fully conformant run; override slots by
+        name from GET_SLOTS."""
+        responses = {
+            'initial': _response(etag='"E1"', body_etag='"E1"',
+                                 role='ReadOnly'),
+            'stability': _response(etag='"E1"', body_etag='"E1"',
+                                   role='ReadOnly'),
+            'conditional_get': _response(status_code=304),
+            'verify_after_412': _response(role='ReadOnly'),
+            'pre_write': _response(etag='"E1"', body_etag='"E1"',
+                                   role='ReadOnly'),
+            'verify_new_role': _response(role='Operator'),
+            'verify_after_replay': _response(role='Operator'),
+            'rotation': _response(etag='"E2"', body_etag='"E2"',
+                                  role='Operator'),
+            'race_read': _response(etag='"E2"', body_etag='"E2"',
+                                   role='Operator'),
+            'verify_race_winner': _response(role='ReadOnly'),
+        }
+        unknown = set(overrides) - set(GET_SLOTS)
+        assert not unknown, 'unknown GET slots: %s' % unknown
+        responses.update(overrides)
+        return [responses[slot] for slot in GET_SLOTS]
+
+    def happy_path_patches(self):
+        return [
+            _response(status_code=412),  # never-issued tag
+            _response(),                 # current tag
+            _response(status_code=412),  # stale replay
+        ]
+
+    def happy_race(self):
+        return [
+            _response(status_code=412), _response(),
+            _response(status_code=412), _response(status_code=412)]
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_etags_pass(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        with mock.patch.object(
+                self.sut, 'get', side_effect=self.happy_path_gets()), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()) as mock_patch:
+            etags.test_etags(self.sut)
+        # exact counts, so a test that silently never ran cannot pass
+        expected = {
+            Assertion.PROTO_ETAG_HEADER_AND_PROPERTY: 1,
+            Assertion.PROTO_ETAG_STABLE_WITHOUT_MODIFICATION: 1,
+            Assertion.PROTO_ETAG_CONDITIONAL_GET: 1,
+            Assertion.PROTO_ETAG_IF_MATCH_ENFORCED: 2,
+            Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED: 1,
+            Assertion.PROTO_ETAG_LOST_UPDATE: 1,
+            Assertion.PROTO_ETAG_ROTATES_ON_WRITE: 1,
+            Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS: 1,
+        }
+        for assertion, count in expected.items():
+            self.assertEqual(self.result(assertion), [Result.PASS] * count,
+                             'assertion %s' % assertion.name)
+        # every write flips RoleId; nothing touches Password
+        for _, kwargs in mock_patch.call_args_list:
+            self.assertIn('RoleId', kwargs['json'])
+            self.assertNotIn('Password', kwargs['json'])
+        self.assertEqual(self.mock_accounts.delete_account.call_count, 1)
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_never_issued_etag_accepted_fails(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        patches = self.happy_path_patches()
+        patches[0] = _response()  # bogus If-Match accepted
+        gets = self.happy_path_gets(
+            verify_after_412=_response(role='Operator'))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(self.sut, 'patch', side_effect=patches):
+            etags.test_etags(self.sut)
+        self.assertIn(Result.FAIL,
+                      self.result(Assertion.PROTO_ETAG_IF_MATCH_ENFORCED))
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_stale_replay_accepted_fails(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        patches = self.happy_path_patches()
+        patches[2] = _response()  # stale If-Match accepted: lost update
+        with mock.patch.object(
+                self.sut, 'get', side_effect=self.happy_path_gets()), \
+                mock.patch.object(self.sut, 'patch', side_effect=patches):
+            etags.test_etags(self.sut)
+        self.assertEqual(self.result(Assertion.PROTO_ETAG_LOST_UPDATE),
+                         [Result.FAIL])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_412_but_write_applied_fails(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        # the rejected write's role shows up on the verification read
+        gets = self.happy_path_gets(
+            verify_after_412=_response(role='Operator'))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED),
+            [Result.FAIL])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_verify_channel_broken_not_tested(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        # Exception-synthesized 600 response: no verification verdict
+        gets = self.happy_path_gets(
+            verify_after_412=_response(status_code=600))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED),
+            [Result.NOT_TESTED])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_write_not_evaluated_not_tested(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        patches = self.happy_path_patches()
+        patches[0] = _response(status_code=401)  # session dropped
+        with mock.patch.object(
+                self.sut, 'get', side_effect=self.happy_path_gets()), \
+                mock.patch.object(self.sut, 'patch', side_effect=patches):
+            etags.test_etags(self.sut)
+        results = self.result(Assertion.PROTO_ETAG_IF_MATCH_ENFORCED)
+        self.assertEqual(results[0], Result.NOT_TESTED)
+        self.assertEqual(
+            self.result(Assertion.PROTO_ETAG_412_WRITE_NOT_APPLIED),
+            [Result.NOT_TESTED])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_accepted_write_not_observable_fails(self, mock_race,
+                                                 mock_sleep):
+        mock_race.return_value = self.happy_race()
+        # the accepted write's role never shows up on the read-back
+        gets = self.happy_path_gets(
+            verify_new_role=_response(role='ReadOnly'))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertIn(Result.FAIL,
+                      self.result(Assertion.PROTO_ETAG_IF_MATCH_ENFORCED))
+        # downstream write tests cannot run without an applied write
+        self.assertEqual(self.result(Assertion.PROTO_ETAG_LOST_UPDATE),
+                         [Result.NOT_TESTED])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_unstable_etag_warns(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        gets = self.happy_path_gets(
+            stability=_response(etag='"E1b"', body_etag='"E1b"',
+                                role='ReadOnly'))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.PROTO_ETAG_STABLE_WITHOUT_MODIFICATION),
+            [Result.WARN])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_header_property_mismatch_warns(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        gets = self.happy_path_gets(
+            initial=_response(etag='"E1"', body_etag='"E1-other"',
+                              role='ReadOnly'))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.PROTO_ETAG_HEADER_AND_PROPERTY),
+            [Result.WARN])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_conditional_get_unsupported_warns(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        gets = self.happy_path_gets(
+            conditional_get=_response(etag='"E1"', body_etag='"E1"',
+                                      role='ReadOnly'))  # full body
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(self.result(Assertion.PROTO_ETAG_CONDITIONAL_GET),
+                         [Result.WARN])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_etag_not_rotated_warns(self, mock_race, mock_sleep):
+        mock_race.return_value = self.happy_race()
+        gets = self.happy_path_gets(
+            rotation=_response(etag='"E1"', body_etag='"E1"',
+                               role='Operator'))  # unchanged
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.PROTO_ETAG_ROTATES_ON_WRITE),
+            [Result.WARN])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_race_two_winners_one_incomplete_fails(self, mock_race,
+                                                   mock_sleep):
+        # Two accepted preconditions fail even when another writer
+        # never completed
+        mock_race.return_value = [
+            _response(), _response(status_code=202),
+            _response(status_code=412), None]
+        with mock.patch.object(
+                self.sut, 'get', side_effect=self.happy_path_gets()), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS),
+            [Result.FAIL])
+        msg = self.sut.results[Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS][0]['msg']
+        self.assertIn('at most one conditional write may succeed', msg)
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_race_202_winner_warns(self, mock_race, mock_sleep):
+        mock_race.return_value = [
+            _response(status_code=412), _response(status_code=202),
+            _response(status_code=412), _response(status_code=412)]
+        # write not yet observable
+        gets = self.happy_path_gets(
+            verify_race_winner=_response(role='Operator'))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS),
+            [Result.WARN])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_race_incomplete_not_tested(self, mock_race, mock_sleep):
+        mock_race.return_value = [None, None, None, None]
+        with mock.patch.object(
+                self.sut, 'get', side_effect=self.happy_path_gets()), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        results = self.result(Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS)
+        self.assertEqual(results, [Result.NOT_TESTED])
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_race_all_412_fails(self, mock_race, mock_sleep):
+        mock_race.return_value = [
+            _response(status_code=412), _response(status_code=412),
+            _response(status_code=412), _response(status_code=412)]
+        with mock.patch.object(
+                self.sut, 'get', side_effect=self.happy_path_gets()), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS),
+            [Result.FAIL])
+
+    @mock.patch('redfish_protocol_validator.etags.requests.Session')
+    def test_race_writers_fire_together(self, mock_session_cls):
+        # every writer gets its own session, sends the same If-Match and
+        # role, and closes its connection
+        sessions = []
+
+        def make_session():
+            session = mock.MagicMock()
+            session.get.return_value = _response()
+            session.patch.return_value = _response(status_code=412)
+            sessions.append(session)
+            return session
+
+        mock_session_cls.side_effect = make_session
+        responses = etags._race_conditional_writes(
+            self.sut, ACCT_URI, '"E1"', 'ReadOnly')
+        self.assertEqual(len(responses), etags.RACE_WRITERS)
+        self.assertEqual(len(sessions), etags.RACE_WRITERS)
+        for response in responses:
+            self.assertEqual(response.status_code, 412)
+        for session in sessions:
+            session.patch.assert_called_once_with(
+                self.sut.rhost + ACCT_URI,
+                json={'RoleId': 'ReadOnly'},
+                headers={'If-Match': '"E1"'}, timeout=30)
+            session.close.assert_called_once_with()
+
+    @mock.patch('redfish_protocol_validator.etags.requests.Session')
+    def test_race_writer_exception_yields_none(self, mock_session_cls):
+        # a raising writer becomes None instead of hanging the barrier
+        def make_session():
+            session = mock.MagicMock()
+            session.get.return_value = _response()
+            session.patch.side_effect = requests.ConnectionError('down')
+            return session
+
+        mock_session_cls.side_effect = make_session
+        responses = etags._race_conditional_writes(
+            self.sut, ACCT_URI, '"E1"', 'ReadOnly')
+        self.assertEqual(responses, [None] * etags.RACE_WRITERS)
+
+    def test_account_setup_failed_not_tested(self):
+        self.mock_accounts.add_account.return_value = (None, None, None)
+        etags.test_etags(self.sut)
+        for assertion in etags.ETAG_ASSERTIONS:
+            self.assertEqual(self.result(assertion), [Result.NOT_TESTED],
+                             'assertion %s' % assertion.name)
+        self.assertEqual(self.mock_accounts.delete_account.call_count, 0)
+
+    def test_no_etag_header_not_tested(self):
+        with mock.patch.object(
+                self.sut, 'get',
+                side_effect=[_response(body_etag='"E1"', role='ReadOnly')]):
+            etags.test_etags(self.sut)
+        for assertion in etags.ETAG_ASSERTIONS:
+            self.assertEqual(self.result(assertion), [Result.NOT_TESTED],
+                             'assertion %s' % assertion.name)
+        self.assertEqual(self.mock_accounts.delete_account.call_count, 1)
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    def test_no_role_property_write_tests_not_tested(self, mock_sleep):
+        gets = [_response(etag='"E1"', body_etag='"E1"'),
+                _response(etag='"E1"', body_etag='"E1"'),
+                _response(status_code=304)]
+        with mock.patch.object(self.sut, 'get', side_effect=gets):
+            etags.test_etags(self.sut)
+        for assertion in [Assertion.PROTO_ETAG_IF_MATCH_ENFORCED,
+                          Assertion.PROTO_ETAG_LOST_UPDATE,
+                          Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS]:
+            self.assertEqual(self.result(assertion), [Result.NOT_TESTED],
+                             'assertion %s' % assertion.name)
+        # the read-only checks still run
+        self.assertEqual(
+            self.result(Assertion.PROTO_ETAG_HEADER_AND_PROPERTY),
+            [Result.PASS])
+        self.assertEqual(self.mock_accounts.delete_account.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittests/test_etags.py
+++ b/unittests/test_etags.py
@@ -16,6 +16,10 @@ ACCT_URI = '/redfish/v1/AccountService/Accounts/9'
 USER = 'rfpvtest'
 PASSWORD = 'OrigPass1_'
 
+# A Date header and a numeric ETag equal to it, as epoch seconds
+DATE_HEADER = 'Thu, 06 Aug 2026 22:00:00 GMT'
+DATE_EPOCH_ETAG = '"1786053600"'
+
 # The GETs test_etags() performs in order, for building mock sequences
 # by name rather than by index
 GET_SLOTS = (
@@ -32,7 +36,8 @@ GET_SLOTS = (
 )
 
 
-def _response(status_code=200, etag=None, body_etag=None, role=None):
+def _response(status_code=200, etag=None, body_etag=None, role=None,
+              date=None):
     resp = mock.MagicMock(spec=requests.Response)
     resp.status_code = status_code
     # Mirror requests: raise_for_status raises only for 4xx and 5xx, so
@@ -42,6 +47,8 @@ def _response(status_code=200, etag=None, body_etag=None, role=None):
     headers = {'Content-Type': 'application/json'}
     if etag is not None:
         headers['ETag'] = etag
+    if date is not None:
+        headers['Date'] = date
     resp.headers = headers
     body = {}
     if body_etag is not None:
@@ -65,6 +72,21 @@ class EtagsNoSut(TestCase):
         self.assertFalse(etags._succeeded(_response(600)))
         self.assertFalse(etags._succeeded(_response(304)))
 
+    def test_tag_tracks_the_clock(self):
+        served = _response(date=DATE_HEADER)
+        # a tag equal to the service clock is a wall-clock value
+        self.assertTrue(
+            etags._tag_tracks_the_clock(served, DATE_EPOCH_ETAG))
+        # a counter or a hash is not
+        self.assertFalse(etags._tag_tracks_the_clock(served, '"42"'))
+        self.assertFalse(
+            etags._tag_tracks_the_clock(served, '"a1b2c3d4"'))
+        self.assertFalse(
+            etags._tag_tracks_the_clock(served, 'W/"a1b2c3d4"'))
+        # unreadable inputs answer neither way
+        self.assertIsNone(etags._tag_tracks_the_clock(_response(), '"1"'))
+        self.assertIsNone(etags._tag_tracks_the_clock(served, None))
+
     def test_evaluated(self):
         self.assertTrue(etags._evaluated(412))
         self.assertTrue(etags._evaluated(500))
@@ -78,17 +100,34 @@ class EtagsNoSut(TestCase):
         self.assertEqual(etags._other_role('Administrator'), 'ReadOnly')
         self.assertEqual(etags._other_role(None), 'ReadOnly')
 
-    def verdict(self, statuses, race_etag='"E1"'):
+    def verdict(self, statuses, race_etag='"E1"', probe=None):
         return etags._race_verdict(statuses, etags._classify_race(statuses),
-                                   race_etag)
+                                   race_etag, probe)
 
     def test_race_verdict_clean_winner_defers(self):
         self.assertIsNone(self.verdict([412, 200, 412, 412]))
 
-    def test_race_verdict_multi_winner_fails(self):
-        result, msg = self.verdict([200, 200, 412, 412])
+    def test_race_verdict_multi_winner_names_cause(self):
+        result, msg = self.verdict([200, 200, 412, 412],
+                                   probe=('not-a-clock', None))
         self.assertEqual(result, Result.FAIL)
-        self.assertIn('at most one conditional write may succeed', msg)
+        self.assertIn('are not atomic', msg)
+        result, msg = self.verdict([200, 200, 412, 412],
+                                   probe=('clock', None))
+        self.assertEqual(result, Result.FAIL)
+        self.assertIn('tracks the service clock', msg)
+        result, msg = self.verdict([200, 200, 412, 412],
+                                   probe=('rotates', 740))
+        self.assertEqual(result, Result.FAIL)
+        self.assertIn('closest it could space two writes was 740 ms', msg)
+        result, msg = self.verdict([200, 200, 412, 412],
+                                   probe=('coarse', 310))
+        self.assertEqual(result, Result.FAIL)
+        self.assertIn('two writes 310 ms apart', msg)
+        result, msg = self.verdict([200, 200, 412, 412],
+                                   probe=('inconclusive', None))
+        self.assertEqual(result, Result.FAIL)
+        self.assertIn('could not determine', msg)
 
     def test_race_verdict_incomplete_and_throttled(self):
         self.assertEqual(self.verdict([200, 412, 412, None])[0],
@@ -366,14 +405,16 @@ class Etags(TestCase):
             [Result.WARN])
 
     @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._probe_tag_resolution')
     @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
     def test_race_two_winners_one_incomplete_fails(self, mock_race,
-                                                   mock_sleep):
+                                                   mock_probe, mock_sleep):
         # Two accepted preconditions fail even when another writer
         # never completed
         mock_race.return_value = [
             _response(), _response(status_code=202),
             _response(status_code=412), None]
+        mock_probe.return_value = ('rotates', 900)
         with mock.patch.object(
                 self.sut, 'get', side_effect=self.happy_path_gets()), \
                 mock.patch.object(
@@ -384,7 +425,82 @@ class Etags(TestCase):
             self.result(Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS),
             [Result.FAIL])
         msg = self.sut.results[Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS][0]['msg']
-        self.assertIn('at most one conditional write may succeed', msg)
+        self.assertIn('closest it could space two writes was 900 ms', msg)
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._probe_tag_resolution')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_race_two_winners_coarse_tag_names_resolution(self, mock_race,
+                                                          mock_probe,
+                                                          mock_sleep):
+        mock_race.return_value = [
+            _response(), _response(),
+            _response(status_code=412), _response(status_code=412)]
+        mock_probe.return_value = ('coarse', 120)
+        with mock.patch.object(
+                self.sut, 'get', side_effect=self.happy_path_gets()), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS),
+            [Result.FAIL])
+        msg = self.sut.results[Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS][0]['msg']
+        self.assertIn('two writes 120 ms apart', msg)
+        self.assertNotIn('not atomic', msg)
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._probe_tag_resolution')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_race_two_winners_opaque_tag_is_not_atomic(self, mock_race,
+                                                       mock_probe,
+                                                       mock_sleep):
+        # The race tag is opaque and the diagnose read carries the
+        # service clock: not a clock value, so the service let two
+        # writers through and the probe is not needed
+        mock_race.return_value = [
+            _response(), _response(),
+            _response(status_code=412), _response(status_code=412)]
+        gets = self.happy_path_gets(
+            verify_race_winner=_response(role='Operator',
+                                         date=DATE_HEADER))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        self.assertEqual(
+            self.result(Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS),
+            [Result.FAIL])
+        msg = self.sut.results[Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS][0]['msg']
+        self.assertIn('are not atomic', msg)
+        self.assertEqual(mock_probe.call_count, 0)
+
+    @mock.patch('redfish_protocol_validator.etags.time.sleep')
+    @mock.patch('redfish_protocol_validator.etags._probe_tag_resolution')
+    @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
+    def test_race_two_winners_clock_tag_is_named(self, mock_race,
+                                                 mock_probe, mock_sleep):
+        # The race tag matches the service clock, so a rotating probe
+        # outcome is promoted to the clock diagnosis
+        mock_race.return_value = [
+            _response(), _response(),
+            _response(status_code=412), _response(status_code=412)]
+        mock_probe.return_value = ('rotates', 900)
+        gets = self.happy_path_gets(
+            race_read=_response(etag=DATE_EPOCH_ETAG,
+                                body_etag=DATE_EPOCH_ETAG,
+                                role='Operator'),
+            verify_race_winner=_response(role='Operator',
+                                         date=DATE_HEADER))
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(
+                    self.sut, 'patch',
+                    side_effect=self.happy_path_patches()):
+            etags.test_etags(self.sut)
+        msg = self.sut.results[Assertion.SEC_ACCOUNTS_SUPPORT_ETAGS][0]['msg']
+        self.assertIn('tracks the service clock', msg)
 
     @mock.patch('redfish_protocol_validator.etags.time.sleep')
     @mock.patch('redfish_protocol_validator.etags._race_conditional_writes')
@@ -509,6 +625,54 @@ class Etags(TestCase):
             self.result(Assertion.PROTO_ETAG_HEADER_AND_PROPERTY),
             [Result.PASS])
         self.assertEqual(self.mock_accounts.delete_account.call_count, 1)
+
+    def probe_with_tags(self, tags):
+        """Run the probe over a scripted sequence of tag reads."""
+        gets = [_response(etag=t, body_etag=t, role='ReadOnly')
+                for t in tags]
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(self.sut, 'patch',
+                                  return_value=_response()):
+            return etags._probe_tag_resolution(self.sut, ACCT_URI)
+
+    def test_probe_tag_resolution_coarse(self):
+        # two consecutive writes produce the same tag
+        outcome, gap = self.probe_with_tags(['"T0"', '"T1"', '"T1"'])
+        self.assertEqual(outcome, 'coarse')
+        self.assertIsInstance(gap, int)
+
+    def test_probe_tag_resolution_rotates(self):
+        tags = ['"T%d"' % i for i in range(1 + 2 * etags.PROBE_PAIRS)]
+        outcome, gap = self.probe_with_tags(tags)
+        self.assertEqual(outcome, 'rotates')
+        self.assertIsInstance(gap, int)
+
+    def test_probe_tag_resolution_coarse_on_later_pair(self):
+        # first pair rotates, second pair repeats a tag
+        outcome, _ = self.probe_with_tags(
+            ['"T0"', '"T1"', '"T2"', '"T3"', '"T3"'])
+        self.assertEqual(outcome, 'coarse')
+
+    def test_probe_tag_resolution_inconclusive_on_rejected_write(self):
+        gets = [_response(etag='"T1"', body_etag='"T1"', role='ReadOnly')]
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(self.sut, 'patch',
+                                  return_value=_response(status_code=412)):
+            outcome, _ = etags._probe_tag_resolution(self.sut, ACCT_URI)
+        self.assertEqual(outcome, 'inconclusive')
+
+    def test_probe_flips_the_role_away_and_back(self):
+        # a coarse pair ends the probe after exactly two writes
+        tags = ['"T0"', '"T1"', '"T1"']
+        gets = [_response(etag=t, body_etag=t, role='ReadOnly')
+                for t in tags]
+        with mock.patch.object(self.sut, 'get', side_effect=gets), \
+                mock.patch.object(self.sut, 'patch',
+                                  return_value=_response()) as mock_patch:
+            etags._probe_tag_resolution(self.sut, ACCT_URI)
+        roles = [kwargs['json']['RoleId']
+                 for _, kwargs in mock_patch.call_args_list[:2]]
+        self.assertEqual(roles, ['Operator', 'ReadOnly'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements the test section proposed in #101.

This adds `etags.py`, run from `perform_tests()`. It creates a temporary `ManagerAccount`, runs the checks from the issue against it in order, and deletes the account when done. Writes alternate the account's `RoleId` between the Operator and ReadOnly standard roles and are verified by reading the property back. Seven new assertions cover the [`If-Match` contract](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.24.0.html#request-headers) under the Protocol Details section; the concurrent-write check logs against the existing `SEC_ACCOUNTS_SUPPORT_ETAGS`, since [§13.5.1](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.24.0.html#account-service-overview)'s "atomic operations" is the clause it exercises.

Scoring follows [DSP0266 1.24.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.24.0.html#etags): checks backed by a shall log FAIL, recommended practice logs WARN. A throttled writer, a dropped connection, or an unreadable verification never logs a failure — those log NOT-TESTED naming the observed statuses, so a fragile service degrades to "not measured" and the exit status is unaffected.

When more than one concurrent writer succeeds, the failure message names the cause where it can be determined: a tag that does not track the service clock changes with the write, so the service accepted preconditions it should have rejected; a clock-derived tag cannot distinguish writers inside its resolution, so the message reports the tag and leaves the service's internals undetermined.

`accounts.add_account()` enables a created account on its PATCH-empty-slot fallback path but not on its POST path, which affects anything that authenticates as the account, such as the `PasswordChangeRequired` flow. These tests no longer depend on that, but I can fix it separately if you'd take it.

Tested with 32 unit tests, no new flake8 findings, and validated against a production BMC, where the sequential checks pass and the concurrent-write check fails with the clock-derived-tag diagnosis.


