### PR TITLE
Add configuration file support for enhanced usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,26 +41,63 @@ If installing from GitHub, you may install the external packages by running:
 
 ## Usage
 
+The Redfish Protocol Validator can be configured using either command-line arguments or a configuration file (config.ini).
+
+### Configuration File
+
+You can use a `config.ini` file in the current working directory with your settings. This is useful for repeated operations with the same configuration.
+
+Example `config.ini`:
+
+```ini
+[Authentication]
+user = username
+password = password
+
+[Connection]
+rhost = https://RedfishIP
+no-cert-check = true
+avoid-http-redirect = true
+
+[Logging]
+log-level = WARNING
+
+[Reporting]
+report-dir = reports
+report-type = both
 ```
-usage: rf_protocol_validator.py [-h] [--version] --user USER --password
-                                PASSWORD --rhost RHOST [--log-level LOG_LEVEL]
-                                [--report-dir REPORT_DIR]
+
+To use a configuration file in a different location, use the `--config` option:
+
+```bash
+python rf_protocol_validator.py --config /path/to/myconfig.ini
+```
+
+**Note:** Command-line arguments always override configuration file settings, ensuring backward compatibility.
+
+### Command-Line Arguments
+
+```
+usage: rf_protocol_validator.py [-h] [--version] [--config CONFIG] [--user USER]
+                                [--password PASSWORD] [--rhost RHOST]
+                                [--log-level LOG_LEVEL] [--report-dir REPORT_DIR]
                                 [--report-type {html,tsv,both}]
                                 [--avoid-http-redirect]
                                 [--no-cert-check | --ca-bundle CA_BUNDLE]
 
 Validate the protocol conformance of a Redfish service
 
-required arguments:
+optional arguments:
+  -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  --config CONFIG, -c CONFIG
+                        path to configuration file; defaults to "config.ini"
+                        in current directory
   --user USER, -u USER  the username for authentication
   --password PASSWORD, -p PASSWORD
                         the password for authentication
   --rhost RHOST, -r RHOST
                         address of the Redfish service (with scheme)
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --version             show program's version number and exit
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         the logging level (default: WARNING)
   --report-dir REPORT_DIR
@@ -77,9 +114,35 @@ optional arguments:
                         the file or directory containing trusted CAs
 ```
 
-Example:
+**Note:** The `--user`, `--password`, and `--rhost` arguments are required if not provided in the configuration file.
 
-    rf_protocol_validator -r https://192.168.1.100 -u USERNAME -p PASSWORD
+### Examples
+
+Using command-line arguments only (backward compatible):
+
+```
+python rf_protocol_validator.py -u username -p password -r https://RedfishIP
+```
+
+Using a configuration file:
+
+```
+# Uses config.ini from current directory
+python rf_protocol_validator.py
+```
+
+Using a custom configuration file:
+
+```
+python rf_protocol_validator.py --config /path/to/custom.ini
+```
+
+Mixing configuration file and command-line arguments (command-line overrides config):
+
+```
+# Uses settings from config.ini but overrides the report directory
+python rf_protocol_validator.py --report-dir /different/output
+```
 
 ## Unit Tests
 

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,35 @@
+# This file contains default configuration settings for the Redfish Protocol Validator
+# All settings can be overridden by command-line arguments
+
+[Authentication]
+# The username for authentication (required if not provided via command line)
+user = 
+
+# The password for authentication (required if not provided via command line)
+password = 
+
+[Connection]
+# The IP address (and port) of the Redfish service (required if not provided via command line)
+# Example: https://RedfishIP
+rhost = 
+
+# Disable verification of host SSL certificates (true/false)
+no-cert-check = true
+
+# The file or directory containing trusted CAs
+# Leave empty if not needed
+ca-bundle = 
+
+# Avoid attempts to generate HTTP redirects for services that do not support HTTP (true/false)
+avoid-http-redirect = false
+
+[Logging]
+# The logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+log-level = WARNING
+
+[Reporting]
+# The directory for generated report files
+report-dir = reports
+
+# The type of report to generate (html, tsv, both)
+report-type = both

--- a/redfish_protocol_validator/console_scripts.py
+++ b/redfish_protocol_validator/console_scripts.py
@@ -4,7 +4,9 @@
 # https://github.com/DMTF/Redfish-Protocol-Validator/blob/main/LICENSE.md
 
 import argparse
+import configparser
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -28,6 +30,76 @@ from redfish_protocol_validator.system_under_test import SystemUnderTest
 tool_version = '1.3.0'
 
 
+def load_config(config_file):
+    """
+    Loads configuration from a config.ini file
+
+    Args:
+        config_file: Path to the configuration file
+
+    Returns:
+        A dictionary containing the configuration values
+    """
+    config = configparser.ConfigParser()
+    config_values = {}
+
+    try:
+        if not os.path.isfile(config_file):
+            return config_values
+        
+        config.read(config_file)
+        
+        # Authentication section
+        if config.has_section('Authentication'):
+            if config.has_option('Authentication', 'user'):
+                user = config.get('Authentication', 'user').strip()
+                if user:
+                    config_values['user'] = user
+            if config.has_option('Authentication', 'password'):
+                password = config.get('Authentication', 'password').strip()
+                if password:
+                    config_values['password'] = password
+        
+        # Connection section
+        if config.has_section('Connection'):
+            if config.has_option('Connection', 'rhost'):
+                rhost = config.get('Connection', 'rhost').strip()
+                if rhost:
+                    config_values['rhost'] = rhost
+            if config.has_option('Connection', 'no-cert-check'):
+                config_values['no_cert_check'] = config.getboolean('Connection', 'no-cert-check')
+            if config.has_option('Connection', 'ca-bundle'):
+                ca_bundle = config.get('Connection', 'ca-bundle').strip()
+                if ca_bundle:
+                    config_values['ca_bundle'] = ca_bundle
+            if config.has_option('Connection', 'avoid-http-redirect'):
+                config_values['avoid_http_redirect'] = config.getboolean('Connection', 'avoid-http-redirect')
+        
+        # Logging section
+        if config.has_section('Logging'):
+            if config.has_option('Logging', 'log-level'):
+                log_level = config.get('Logging', 'log-level').strip()
+                if log_level:
+                    config_values['log_level'] = log_level
+        
+        # Reporting section
+        if config.has_section('Reporting'):
+            if config.has_option('Reporting', 'report-dir'):
+                report_dir = config.get('Reporting', 'report-dir').strip()
+                if report_dir:
+                    config_values['report_dir'] = report_dir
+            if config.has_option('Reporting', 'report-type'):
+                report_type = config.get('Reporting', 'report-type').strip()
+                if report_type:
+                    config_values['report_type'] = report_type
+        
+    except Exception as err:
+        print("WARNING: Error reading config file '{}': {}".format(config_file, err))
+        return {}
+    
+    return config_values
+
+
 def perform_tests(sut: SystemUnderTest):
     """Perform the protocol validation tests on the resources."""
     protocol_details.test_protocol_details(sut)
@@ -42,21 +114,24 @@ def main():
         description='Validate the protocol conformance of a Redfish service')
     parser.add_argument('--version', action='version',
                         version='Redfish-Protocol-Validator %s' % tool_version)
-    parser.add_argument('--user', '-u', type=str, required=True,
+    parser.add_argument('--config', '-c', type=str, default='config.ini',
+                        help='path to configuration file; defaults to '
+                             '"config.ini" in current directory')
+    parser.add_argument('--user', '-u', type=str,
                         help='the username for authentication')
-    parser.add_argument('--password', '-p', type=str, required=True,
+    parser.add_argument('--password', '-p', type=str,
                         help='the password for authentication')
-    parser.add_argument('--rhost', '-r', type=str, required=True,
+    parser.add_argument('--rhost', '-r', type=str,
                         help='address of the Redfish service (with scheme)')
-    parser.add_argument('--log-level', type=str, default='WARNING',
+    parser.add_argument('--log-level', type=str,
                         help='the logging level (default: WARNING)',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'])
-    parser.add_argument('--report-dir', type=str, default='reports',
+    parser.add_argument('--report-dir', type=str,
                         help='the directory for generated report files '
                              '(default: "reports")')
     parser.add_argument('--report-type', choices=['html', 'tsv', 'both'],
                         help='the type of report to generate: html, tsv, or '
-                             'both (default: both)', default='both')
+                             'both (default: both)')
     parser.add_argument('--avoid-http-redirect', action='store_true',
                         help='avoid attempts to generate HTTP redirects for '
                              'services that do not support HTTP')
@@ -66,6 +141,44 @@ def main():
     cert_g.add_argument('--ca-bundle', type=str,
                         help='the file or directory containing trusted CAs')
     args = parser.parse_args()
+
+    # Load configuration from file
+    config_values = load_config(args.config)
+
+    # Required arguments: rhost, user, password
+    if args.rhost is None:
+        args.rhost = config_values.get('rhost')
+    if args.user is None:
+        args.user = config_values.get('user')
+    if args.password is None:
+        args.password = config_values.get('password')
+    
+    # Check if required arguments are present
+    if args.rhost is None:
+        print("ERROR: Redfish service host is required (provide via --rhost or config file)")
+        sys.exit(1)
+    if args.user is None:
+        print("ERROR: Username is required (provide via --user or config file)")
+        sys.exit(1)
+    if args.password is None:
+        print("ERROR: Password is required (provide via --password or config file)")
+        sys.exit(1)
+    
+    # Optional string arguments
+    if args.log_level is None:
+        args.log_level = config_values.get('log_level', 'WARNING')
+    if args.report_dir is None:
+        args.report_dir = config_values.get('report_dir', 'reports')
+    if args.report_type is None:
+        args.report_type = config_values.get('report_type', 'both')
+    if args.ca_bundle is None:
+        args.ca_bundle = config_values.get('ca_bundle')
+    
+    # Optional Boolean arguments
+    if not args.no_cert_check and 'no_cert_check' in config_values:
+        args.no_cert_check = config_values['no_cert_check']
+    if not args.avoid_http_redirect and 'avoid_http_redirect' in config_values:
+        args.avoid_http_redirect = config_values['avoid_http_redirect']
 
     # set logging level
     log_level = getattr(logging, args.log_level.upper())


### PR DESCRIPTION
This commit introduces config.ini support to the Redfish Protocol Validator, allowing users to configure tool settings via a configuration file in addition to command-line arguments.

Key features:
- Added config.ini template file with all configurable settings
- New --config/-c option to specify custom configuration file path
- Configuration sections: Authentication, Connection, Logging, and Reporting
- Settings precedence: Command-line > Config file > Defaults
- Made --user, --password, and --rhost optional when provided in config
- Full backward compatibility with existing command-line usage

Benefits:
- Simplified repeated operations with consistent settings
- Better user experience with reduced command-line verbosity
- Flexible configuration mixing (config file + CLI overrides)

Updated documentation with configuration file usage examples and comprehensive command-line reference.